### PR TITLE
Update legacy imports to UnifiedVantaCore

### DIFF
--- a/dialogue_manager.py
+++ b/dialogue_manager.py
@@ -29,12 +29,8 @@ try:
         trace_event,
     )
 except ImportError:
-    # Fallback for development/testing
-    import os
-    import sys
-
-    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "Vanta"))
-    from core.vanta_core import (
+    # Local fallback for development/testing
+    from .UnifiedVantaCore import (
         generate_internal_dialogue_message,
         get_component,
         publish_event,

--- a/external_echo_layer.py
+++ b/external_echo_layer.py
@@ -13,7 +13,8 @@ import time
 import uuid
 from typing import Any, Callable, Protocol, runtime_checkable
 
-from .vanta_core import VantaCore  # VantaCore integration
+# Use UnifiedVantaCore for all orchestration
+from .UnifiedVantaCore import UnifiedVantaCore as VantaCore  # VantaCore integration
 
 # --- Logging Setup ---
 logging.basicConfig(

--- a/integration/art_integration_example.py
+++ b/integration/art_integration_example.py
@@ -37,7 +37,7 @@ except ImportError:
 
 # Import VANTA components
 try:
-    from Vanta.core.vanta_core import VantaCore
+    from Vanta.core.UnifiedVantaCore import UnifiedVantaCore as VantaCore
     from Vanta.interfaces.rag_interface import BaseRagInterface
     from Vanta.interfaces.memory_interface import BaseMemoryInterface
     from Vanta.interfaces.model_manager import ModelManager

--- a/integration/art_integration_example.py.temp
+++ b/integration/art_integration_example.py.temp
@@ -36,7 +36,7 @@ except ImportError:
 
 # Import VANTA components
 try:
-    from Vanta.core.vanta_core import VantaCore
+    from Vanta.core.UnifiedVantaCore import UnifiedVantaCore as VantaCore
     from Vanta.interfaces.rag_interface import BaseRagInterface
     from Vanta.interfaces.memory_interface import BaseMemoryInterface
     from Vanta.interfaces.model_manager import ModelManager 

--- a/training/arc_grid_trainer.py
+++ b/training/arc_grid_trainer.py
@@ -20,7 +20,7 @@ import torch.nn as nn
 import torch.optim as optim
 from torch.utils.data import DataLoader
 
-from Voxsigil_Library.voxsigil_supervisor.vanta.Vanta_Core import VantaCore
+from Vanta.core.UnifiedVantaCore import UnifiedVantaCore as VantaCore
 
 # Import GRID-Former components
 try:


### PR DESCRIPTION
## Summary
- use `UnifiedVantaCore` in `external_echo_layer`
- update `dialogue_manager` fallback imports
- update ART integration examples to reference `UnifiedVantaCore`
- fix import path in `arc_grid_trainer`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6846d5049b948324ae523cea31fc9eae