### PR TITLE
Implement Phase 4/5 bindings

### DIFF
--- a/UnifiedVantaCore.py
+++ b/UnifiedVantaCore.py
@@ -607,6 +607,12 @@ class UnifiedVantaCore:
                 instance = NullAgent()
 
             try:
+                if hasattr(instance, "initialize_subsystem"):
+                    instance.initialize_subsystem(self)
+            except Exception as e:  # noqa: BLE001
+                logger.error(f"Failed to initialize {cls.__name__}: {e}")
+
+            try:
                 self.agent_registry.register_agent(
                     cls.__name__,
                     instance,

--- a/agents/base.py
+++ b/agents/base.py
@@ -1,17 +1,43 @@
+from ..UnifiedAsyncBus import AsyncMessage, MessageType
+
+
 class BaseAgent:
-    """Base class for all agents."""
+    """Base class for all agents with async bus integration."""
 
     sigil: str = ""
     invocations: list[str] = []
     sub_agents: list[str] = []
 
-    def initialize_subsystem(self, vanta_core):
-        """Initialize any subsystem connections."""
-        pass
+    def __init__(self, vanta_core=None):
+        self.vanta_core = vanta_core
 
-    def on_gui_call(self, *args, **kwargs):
-        """Handle GUI-triggered calls."""
-        pass
+    def initialize_subsystem(self, vanta_core):
+        """Initialize subsystem and register with async bus."""
+        self.vanta_core = vanta_core
+        if vanta_core and hasattr(vanta_core, "async_bus"):
+            try:
+                vanta_core.async_bus.register_component(self.__class__.__name__)
+                vanta_core.async_bus.subscribe(
+                    self.__class__.__name__,
+                    MessageType.USER_INTERACTION,
+                    self.handle_message,
+                )
+            except Exception:
+                pass
+
+    def handle_message(self, message: AsyncMessage):
+        """Handle messages from the async bus (override in subclasses)."""
+        return None
+
+    def on_gui_call(self, payload=None):
+        """Publish a generic user interaction message on GUI trigger."""
+        if self.vanta_core and hasattr(self.vanta_core, "async_bus"):
+            msg = AsyncMessage(
+                MessageType.USER_INTERACTION,
+                self.__class__.__name__,
+                payload,
+            )
+            self.vanta_core.async_bus.publish(msg)
 
 
 class NullAgent(BaseAgent):

--- a/agents/bridgeflesh.py
+++ b/agents/bridgeflesh.py
@@ -12,14 +12,14 @@ class BridgeFlesh(BaseAgent):
     invocations = ["Link Bridge", "Fuse layers"]
 
     def __init__(self, vanta_core=None):
-        self.vanta_core = vanta_core
+        super().__init__(vanta_core)
         self.vmb_handler = None
 
     def initialize_subsystem(self, vanta_core):
+        super().initialize_subsystem(vanta_core)
         self.vanta_core = vanta_core
         self.vmb_handler = vanta_core.get_component("vmb_integration_handler")
         if vanta_core and hasattr(vanta_core, "async_bus"):
-            vanta_core.async_bus.register_component("BridgeFlesh")
             vanta_core.async_bus.subscribe(
                 "BridgeFlesh",
                 MessageType.SYSTEM_COMMAND,

--- a/agents/codeweaver.py
+++ b/agents/codeweaver.py
@@ -14,14 +14,14 @@ class CodeWeaver(BaseAgent):
 
 
     def __init__(self, vanta_core=None):
-        self.vanta_core = vanta_core
+        super().__init__(vanta_core)
         self.meta_learner = None
 
     def initialize_subsystem(self, vanta_core):
+        super().initialize_subsystem(vanta_core)
         self.vanta_core = vanta_core
         self.meta_learner = vanta_core.get_component("meta_learner")
         if vanta_core and hasattr(vanta_core, "async_bus"):
-            vanta_core.async_bus.register_component("CodeWeaver")
             vanta_core.async_bus.subscribe(
                 "CodeWeaver",
                 MessageType.REASONING_REQUEST,

--- a/agents/dreamer.py
+++ b/agents/dreamer.py
@@ -13,14 +13,14 @@ class Dreamer(BaseAgent):
 
 
     def __init__(self, vanta_core=None):
-        self.vanta_core = vanta_core
+        super().__init__(vanta_core)
         self.art_controller = None
 
     def initialize_subsystem(self, vanta_core):
+        super().initialize_subsystem(vanta_core)
         self.vanta_core = vanta_core
         self.art_controller = vanta_core.get_component("art_controller")
         if vanta_core and hasattr(vanta_core, "async_bus"):
-            vanta_core.async_bus.register_component("Dreamer")
             vanta_core.async_bus.subscribe(
                 "Dreamer",
                 MessageType.USER_INTERACTION,

--- a/agents/entropybard.py
+++ b/agents/entropybard.py
@@ -12,11 +12,12 @@ class EntropyBard(BaseAgent):
     invocations = ["Sing Bard", "Unleash entropy"]
 
     def __init__(self, vanta_core=None):
-        self.vanta_core = vanta_core
+        super().__init__(vanta_core)
         self.rag_handler = None
         self.rag_interface = None
 
     def initialize_subsystem(self, vanta_core):
+        super().initialize_subsystem(vanta_core)
         self.vanta_core = vanta_core
         try:
             from rag_integration_handler import RagIntegrationHandler
@@ -27,7 +28,6 @@ class EntropyBard(BaseAgent):
             logger.warning(f"RAG subsystem unavailable: {e}")
 
         if vanta_core and hasattr(vanta_core, "async_bus"):
-            vanta_core.async_bus.register_component("EntropyBard")
             vanta_core.async_bus.subscribe(
                 "EntropyBard",
                 MessageType.PROCESSING_REQUEST,

--- a/agents/mirrorwarden.py
+++ b/agents/mirrorwarden.py
@@ -13,14 +13,14 @@ class MirrorWarden(BaseAgent):
 
 
     def __init__(self, vanta_core=None):
-        self.vanta_core = vanta_core
+        super().__init__(vanta_core)
         self.meta_learner = None
 
     def initialize_subsystem(self, vanta_core):
+        super().initialize_subsystem(vanta_core)
         self.vanta_core = vanta_core
         self.meta_learner = vanta_core.get_component("meta_learner")
         if vanta_core and hasattr(vanta_core, "async_bus"):
-            vanta_core.async_bus.register_component("MirrorWarden")
             vanta_core.async_bus.subscribe(
                 "MirrorWarden",
                 MessageType.REASONING_REQUEST,

--- a/agents/pulsesmith.py
+++ b/agents/pulsesmith.py
@@ -14,17 +14,17 @@ class PulseSmith(BaseAgent):
 
 
     def __init__(self, vanta_core=None):
-        self.vanta_core = vanta_core
+        super().__init__(vanta_core)
         self.gridformer = None
 
     def initialize_subsystem(self, vanta_core):
+        super().initialize_subsystem(vanta_core)
         self.vanta_core = vanta_core
         self.gridformer = (
             vanta_core.get_component("gridformer_connector")
             or vanta_core.get_component("gridformer")
         )
         if vanta_core and hasattr(vanta_core, "async_bus"):
-            vanta_core.async_bus.register_component("PulseSmith")
             vanta_core.async_bus.subscribe(
                 "PulseSmith",
                 MessageType.PROCESSING_REQUEST,

--- a/dynamic_gridformer_gui.py
+++ b/dynamic_gridformer_gui.py
@@ -266,6 +266,22 @@ class DynamicGridFormerGUI:
         # Discover models
         self._discover_models()
 
+    def add_button(self, label: str, command) -> None:
+        """Add a simple button to the bottom of the GUI."""
+        if not hasattr(self, "_agent_button_frame"):
+            self._agent_button_frame = tk.Frame(self.root, bg="#2a2a4e")
+            self._agent_button_frame.pack(side=tk.BOTTOM, fill=tk.X, pady=5)
+        tk.Button(
+            self._agent_button_frame,
+            text=label,
+            command=command,
+            bg="#4ecdc4",
+            fg="white",
+            font=("Consolas", 9, "bold"),
+            relief=tk.RAISED,
+            bd=1,
+        ).pack(side=tk.LEFT, padx=2)
+
     def _setup_gui(self):
         """Set up the main GUI components."""
         # Main frame that contains everything
@@ -841,10 +857,17 @@ class DynamicGridFormerGUI:
         )
 
 
-def main():
+def main(agent_registry=None):
     """Main entry point for the application."""
     root = tk.Tk()
-    DynamicGridFormerGUI(root)
+    gui = DynamicGridFormerGUI(root)
+    try:
+        if agent_registry:
+            from gui_utils import bind_agent_buttons
+
+            bind_agent_buttons(gui.root, agent_registry)
+    except Exception:
+        pass
     root.mainloop()
 
 

--- a/gui_utils.py
+++ b/gui_utils.py
@@ -1,0 +1,28 @@
+import tkinter as tk
+from typing import Optional
+
+
+def bind_agent_buttons(root: tk.Misc, registry) -> None:
+    """Bind agent on_gui_call buttons to a Tkinter root or frame."""
+    if not root or not registry:
+        return
+
+    frame = tk.Frame(root, bg="#2a2a4e")
+    frame.pack(side=tk.BOTTOM, fill=tk.X, pady=5)
+
+    tk.Label(frame, text="Agents", bg="#2a2a4e", fg="#00ff88", font=("Consolas", 10, "bold")).pack(side=tk.LEFT, padx=5)
+
+    for agent_name, agent in registry.get_all_agents():
+        if not hasattr(agent, "on_gui_call"):
+            continue
+        btn = tk.Button(
+            frame,
+            text=f"Invoke {agent_name}",
+            command=lambda a=agent: a.on_gui_call(),
+            bg="#4ecdc4",
+            fg="white",
+            font=("Consolas", 9, "bold"),
+            relief=tk.RAISED,
+            bd=1,
+        )
+        btn.pack(side=tk.LEFT, padx=2)

--- a/launch_gui.py
+++ b/launch_gui.py
@@ -185,7 +185,8 @@ def launch_gui_with_fallback():
 
         # Launch the main GUI
         logger.info("🎨 Starting GUI main loop...")
-        dynamic_gridformer_gui.main()
+        registry = core.agent_registry if core else None
+        dynamic_gridformer_gui.main(registry)
 
     except ImportError as e:
         logger.error(f"❌ Failed to import dynamic_gridformer_gui: {e}")
@@ -223,6 +224,14 @@ def launch_gui_with_fallback():
             tk.Label(root, text=status_text, font=("Courier", 10), justify="left").pack(
                 pady=10
             )
+
+            try:
+                from gui_utils import bind_agent_buttons
+
+                registry = core.agent_registry if core else None
+                bind_agent_buttons(root, registry)
+            except Exception:
+                pass
 
             def show_error():
                 messagebox.showerror("Error Details", f"Import Error: {e}")

--- a/vmb_final_demo.py
+++ b/vmb_final_demo.py
@@ -11,6 +11,9 @@ from pathlib import Path
 import yaml
 from vmb_activation import CopilotSwarm
 from vmb_production_executor import ProductionTaskExecutor
+from UnifiedVantaCore import UnifiedVantaCore
+import tkinter as tk
+from gui_utils import bind_agent_buttons
 
 # Add project paths
 PROJECT_ROOT = Path(__file__).resolve().parent
@@ -33,6 +36,8 @@ async def demonstrate_vmb_system():
     print(f"🤖 Agent Class: {config.get('agent_class', 'CopilotSwarm')}")
     print(f"⚔️ Swarm Variant: {config.get('swarm_variant', 'RPG_Sentinel')}")
     print(f"🎯 Roles: {config.get('role_scope', [])}")
+
+    core = UnifiedVantaCore()
 
     # Initialize VMB CopilotSwarm
     print("\n🚀 Initializing VMB CopilotSwarm...")
@@ -81,6 +86,13 @@ async def demonstrate_vmb_system():
     print("✅ BootSigil Directive: COMPLETED")
     print("\n🚀 Ready for production use!")
     print("🔮 Bound by sigil: ⟠∆∇𓂀")
+
+    # Simple GUI to trigger agents
+    root = tk.Tk()
+    root.title("Agent Controls")
+    bind_agent_buttons(root, core.agent_registry)
+    tk.Button(root, text="Close", command=root.quit).pack(pady=5)
+    root.mainloop()
 
 
 if __name__ == "__main__":

--- a/vmb_gui_launcher.py
+++ b/vmb_gui_launcher.py
@@ -223,6 +223,14 @@ class VMBGUIIntegration:
             # Add VMB integration panel
             self._add_vmb_panel()
 
+            try:
+                from gui_utils import bind_agent_buttons
+
+                if self.vanta_core and self.vanta_core.agent_registry:
+                    bind_agent_buttons(self.root, self.vanta_core.agent_registry)
+            except Exception:
+                pass
+
             logger.info("✅ GUI initialized with VMB integration")
             return True
 


### PR DESCRIPTION
## Summary
- add helper `gui_utils.bind_agent_buttons`
- integrate async bus setup in `BaseAgent` and register all agents in `UnifiedVantaCore`
- connect GUI buttons to agents in `launch_gui`, `vmb_gui_launcher` and `vmb_final_demo`
- expose `add_button` helper and registry param in `dynamic_gridformer_gui`
- ensure specialized agents call base initialization

## Testing
- `python -m py_compile gui_utils.py dynamic_gridformer_gui.py launch_gui.py vmb_gui_launcher.py vmb_final_demo.py UnifiedVantaCore.py agents/*.py`
- `pytest -q` *(fails: ImportError while importing tests)*

------
https://chatgpt.com/codex/tasks/task_e_684715ef9cd88324b6cd4fde3a7611d0