### PR TITLE
Implement phase 6 & 7 integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 This repository hosts the VoxSigil experimental agent framework. It bundles the
 ``UnifiedVantaCore`` orchestration engine, a collection of 30+ agents and a
-Tkinter based GUI for visual model interaction.
+Tkinter based GUI for visual model interaction. Phase 6 and Phase 7 of the
+integration plan are now complete: agents live under the ``agents`` package and
+validation tools generate status reports.
 
 ## Usage
 
@@ -22,10 +24,13 @@ Tkinter based GUI for visual model interaction.
    ```
 
    Each registered agent will appear as a button at the bottom of the interface
-   allowing quick invocation.
+   allowing quick invocation. Speech controls (TTS/STT) are available through
+   the ``Carla`` and ``Wendy`` agents when the speech integration handler is
+   loaded.
 
 ## Contents
 
 * `AGENTS.md` – manifest describing every VoxSigil agent
 * `docs/PROGRESS_PLAN.md` – high level integration roadmap
+* `docs/SYSTEM_OVERVIEW.md` – summary of components and data flow
 * `agent_validation.py` – simple integrity checker

--- a/UnifiedAgentRegistry.py
+++ b/UnifiedAgentRegistry.py
@@ -14,6 +14,8 @@ class UnifiedAgentRegistry:
         self, name: str, agent: object, metadata: Optional[Dict[str, Any]] = None
     ):
         """Register an agent by name with optional metadata."""
+        if name in self.agents:
+            self.logger.warning(f"Agent '{name}' already registered – replacing entry")
         self.agents[name] = {"agent": agent, "metadata": metadata or {}}
         self.logger.info(f"Agent '{name}' registered")
 

--- a/UnifiedVantaCore.py
+++ b/UnifiedVantaCore.py
@@ -637,6 +637,8 @@ class UnifiedVantaCore:
             "CodeWeaver": "meta_learner",
             "Dreamer": "art_controller",
             "BridgeFlesh": "vmb_integration_handler",
+            "Carla": "speech_integration_handler",
+            "Wendy": "speech_integration_handler",
         }
 
         for agent_name, component_key in mapping.items():

--- a/agents/base.py
+++ b/agents/base.py
@@ -61,6 +61,7 @@ class BaseAgent:
 
     def on_gui_call(self, payload=None):
         """Publish a generic user interaction message on GUI trigger."""
+        logger.info(f"GUI invoked {self.__class__.__name__} with payload={payload}")
         if self.vanta_core and hasattr(self.vanta_core, "async_bus"):
             msg = AsyncMessage(
                 MessageType.USER_INTERACTION,

--- a/agents/carla.py
+++ b/agents/carla.py
@@ -6,3 +6,8 @@ class Carla(BaseAgent):
 
     def __init__(self, vanta_core=None):
         super().__init__(vanta_core)
+        self.speech_handler = None
+
+    def initialize_subsystem(self, vanta_core):
+        super().initialize_subsystem(vanta_core)
+        self.speech_handler = vanta_core.get_component("speech_integration_handler")

--- a/agents/wendy.py
+++ b/agents/wendy.py
@@ -6,3 +6,8 @@ class Wendy(BaseAgent):
 
     def __init__(self, vanta_core=None):
         super().__init__(vanta_core)
+        self.speech_handler = None
+
+    def initialize_subsystem(self, vanta_core):
+        super().initialize_subsystem(vanta_core)
+        self.speech_handler = vanta_core.get_component("speech_integration_handler")

--- a/docs/PROGRESS_PLAN.md
+++ b/docs/PROGRESS_PLAN.md
@@ -75,7 +75,7 @@ Move agent modules to `agents/` and update imports accordingly:
 
 Create similar directories for `interfaces/`, `core/`, and `services/` if needed to reduce clutter.
 
-*Status:* Modules relocated under `agents/` with imports updated. Core initialization registers all agents on startup.
+*Status:* **Completed (2025‑06‑09)** – Modules relocated under `agents/` with imports updated. Core initialization registers all agents on startup.
 
 ## Phase 7 – Integrity & Validation Tools
 
@@ -84,7 +84,7 @@ Implement scripts to generate:
 - `agent_status.log` – log of missing imports or registration gaps.
 - `agent_graph.json` – optional connectivity graph for visualization.
 
-*Status:* `agent_validation.py` generates the above files.
+*Status:* **Completed (2025‑06‑09)** – `agent_validation.py` generates the above files and produces `agents.json`, `agent_graph.json` and `agent_status.log`.
 
 ## Outstanding Items
 

--- a/docs/SYSTEM_OVERVIEW.md
+++ b/docs/SYSTEM_OVERVIEW.md
@@ -1,0 +1,31 @@
+# System Overview
+
+This document provides a high level summary of the VoxSigil / Vanta ecosystem.
+
+## Components
+
+- **UnifiedVantaCore** – central orchestration engine that registers and manages all agents. It exposes an async bus and event bus so subsystems can communicate.
+- **Agents** – 30+ modular agents defined in `AGENTS.md`. Each agent implements `initialize_subsystem()` and `on_gui_call()` for GUI triggers.
+- **ART Module** – adaptive resonance theory engine used for pattern recognition. Integrated via the `Dreamer` guardian agent.
+- **BLT‑RAG** – retrieval augmented generation pipeline connected through the `EntropyBard` guardian.
+- **GridFormer Connector** – links trained GridFormer models for ARC tasks. Managed by the `PulseSmith` agent.
+- **Meta Learner** – meta-learning interface mapped to the `MirrorWarden` and `CodeWeaver` agents.
+- **Speech System** – async TTS and STT engines available via the `SpeechIntegrationHandler`. Agents `Carla` and `Wendy` expose speech control through the GUI.
+- **GUI** – `dynamic_gridformer_gui.py` launches a Tkinter interface and automatically binds buttons for each agent.
+
+## Data Flow
+
+1. `launch_gui.py` initializes `UnifiedVantaCore`, loads the speech and VMB integrations, and registers all agents.
+2. The GUI discovers registered agents and creates buttons for each using `gui_utils.bind_agent_buttons`.
+3. When a user activates an agent button, the agent publishes a message on the async bus. Subsystems (RAG, GridFormer, ART, speech, etc.) listen and respond.
+4. Results are routed back through the event bus and displayed in the GUI.
+
+## Logs and Validation
+
+Run `python agent_validation.py` to generate:
+- `agents.json` – current agent definitions
+- `agent_status.log` – registration and import status
+- `agent_graph.json` – basic connectivity graph
+
+Log files such as `vantacore_grid_former_integration.log` and component-specific logs provide additional diagnostics during runtime.
+


### PR DESCRIPTION
## Summary
- mark phases 6/7 complete in progress plan
- describe phase completion and speech controls in README
- add system overview document
- improve base agent logging
- warn when re-registering agents
- connect Carla/Wendy agents to speech system
- map speech handler in UnifiedVantaCore
- regenerate agent validation outputs

## Testing
- `python agent_validation.py`

------
https://chatgpt.com/codex/tasks/task_e_68472122b4ac8324978d06de3d2bdf50