### PR TITLE
Fix syntax bugs and regenerate validation logs

### DIFF
--- a/blt_supervisor_integration.py
+++ b/blt_supervisor_integration.py
@@ -671,7 +671,9 @@ class TinyLlamaIntegration:
 
         except Exception as e:
             logger.error(f"Error creating supervisor: {e}")
-            return None    def _create_tinyllama_interface(self):
+            return None
+
+    def _create_tinyllama_interface(self):
         """
         Create a TinyLlama LLM interface for the supervisor.
 

--- a/core/grid_distillation.py
+++ b/core/grid_distillation.py
@@ -264,9 +264,9 @@ class DistillationTrainer:
         optimizer = torch.optim.AdamW(
             self.student_model.parameters(),
             lr=lr,
-            weight_decay=weight_decay
+            weight_decay=weight_decay,
         )
-          scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
+        scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
             optimizer,
             mode='min',
             factor=0.5,

--- a/core/model_architecture_fixer.py
+++ b/core/model_architecture_fixer.py
@@ -180,6 +180,7 @@ class BasicGridFormer(nn.Module):
         logits = logits.view(batch_size, height, width, -1)
         
         return logits
+'''
 
 def load_basic_gridformer(model_path: str):
     """Load a basic GridFormer model from checkpoint"""
@@ -204,7 +205,8 @@ def generate_enhanced_gridformer_class(analysis: Dict[str, Any]) -> str:
     config = analysis.get("config", {})
     hidden_dim = config.get("hidden_dim", 256)
     num_layers = config.get("num_layers", 6)
-    return f"""
+
+    template = f"""
 class EnhancedGridFormer(nn.Module):
     def __init__(self):
         super().__init__()
@@ -214,6 +216,7 @@ class EnhancedGridFormer(nn.Module):
     def forward(self, x):
         return x
 """
+    return template
 
 
 def main():

--- a/vanta_integration_backup.py
+++ b/vanta_integration_backup.py
@@ -337,7 +337,9 @@ class VantaGUIIntegration:
             self.current_training_job.current_step = data.get("step", 0)
             self.current_training_job.loss = data.get("loss", None)
 
-            self._notify_status_callbacks("progress", data)    def on_training_completed(self, event):
+            self._notify_status_callbacks("progress", data)
+
+    def on_training_completed(self, event):
         """Handle training completed event"""
         self.logger.info(f"Training completed: {event['data']}")
         if self.current_training_job:

--- a/vanta_orchestrator.py
+++ b/vanta_orchestrator.py
@@ -1217,7 +1217,8 @@ def run_diagnostic():
         # Check if real implementation is being used
         using_real = (
             hasattr(llm_interface, "real_llm") and llm_interface.real_llm is not None
-        )        real_type = type(llm_interface.real_llm).__name__ if using_real else "None"
+        )
+        real_type = type(llm_interface.real_llm).__name__ if using_real else "None"
         print(
             f"Initialized ({'real' if using_real else 'mock'} implementation - {real_type})"
         )


### PR DESCRIPTION
## Summary
- fix newline bug in TinyLlama integration helper
- correct indentation in grid distillation trainer
- close string literal in model_architecture_fixer and refactor
- split progress callback from completion handler in vanta integration backup
- clean llm interface diagnostic logging
- regenerate agent validation outputs

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python agent_validation.py`

------
https://chatgpt.com/codex/tasks/task_e_684726ace53c832491a9b60c70cc1084