### PR TITLE
Phase 10: integrate agent registry and GUI

### DIFF
--- a/Vanta/core/UnifiedVantaCore.py
+++ b/Vanta/core/UnifiedVantaCore.py
@@ -567,37 +567,20 @@ class UnifiedVantaCore:
             except Exception as e:
                 logger.error(f"Failed to register VantaSupervisor as core agent: {e}")
 
-        # Register all defined agents from AGENTS.md
-        agent_classes = [
-            Phi,
-            Voxka,
-            Gizmo,
-            Nix,
-            Echo,
-            Oracle,
-            Astra,
-            Warden,
-            Nebula,
-            Orion,
-            Evo,
-            OrionApprentice,
-            SocraticEngine,
-            Dreamer,
-            EntropyBard,
-            CodeWeaver,
-            EchoLore,
-            MirrorWarden,
-            PulseSmith,
-            BridgeFlesh,
-            Sam,
-            Dave,
-            Carla,
-            Andy,
-            Wendy,
-            VoxAgent,
-            SDKContext,
-            SleepTimeComputeAgent,
-        ]
+        # Register all defined agents dynamically from agents.__all__
+        agent_classes = []
+        try:
+            from agents import __all__ as agent_names  # type: ignore
+            import agents as agent_pkg
+
+            for name in agent_names:
+                if name in {"BaseAgent", "NullAgent"}:
+                    continue
+                cls = getattr(agent_pkg, name, None)
+                if cls:
+                    agent_classes.append(cls)
+        except Exception as e:  # noqa: BLE001
+            logger.error(f"Failed to gather agent classes dynamically: {e}")
 
         for cls in agent_classes:
             try:
@@ -619,6 +602,8 @@ class UnifiedVantaCore:
                     {
                         "sigil": getattr(cls, "sigil", ""),
                         "invocations": getattr(cls, "invocations", []),
+                        "tags": getattr(cls, "tags", []),
+                        "doc": getattr(cls, "__doc__", ""),
                     },
                 )
             except Exception as e:

--- a/agent_status.log
+++ b/agent_status.log
@@ -1,4 +1,4 @@
-UnifiedVantaCore import failed: No module named 'jsonschema'
+UnifiedVantaCore import failed: No module named 'Vanta.interfaces'
 Agent Phi not registered in VantaCore
 Agent Voxka not registered in VantaCore
 Agent Gizmo not registered in VantaCore

--- a/agents/bridgeflesh.py
+++ b/agents/bridgeflesh.py
@@ -7,13 +7,13 @@ class BridgeFlesh(BaseAgent):
     invocations = ['Link Bridge', 'Fuse layers']
 
     def initialize_subsystem(self, core):
-        # Optional: bind to subsystem if defined
-        pass
+        """Bind to the VMB integration handler subsystem."""
+        super().initialize_subsystem(core)
+        self.subsystem = core.get_component("vmb_integration_handler")
 
     def on_gui_call(self):
         # Optional: link to GUI invocation
         super().on_gui_call()
 
     def bind_echo_routes(self):
-        # Optional: connect signals to/from UnifiedAsyncBus
-        pass
+        super().bind_echo_routes()

--- a/agents/codeweaver.py
+++ b/agents/codeweaver.py
@@ -7,13 +7,13 @@ class CodeWeaver(BaseAgent):
     invocations = ['Weave Code', 'Forge logic']
 
     def initialize_subsystem(self, core):
-        # Optional: bind to subsystem if defined
-        pass
+        """Bind to the MetaLearner subsystem."""
+        super().initialize_subsystem(core)
+        self.subsystem = core.get_component("meta_learner")
 
     def on_gui_call(self):
         # Optional: link to GUI invocation
         super().on_gui_call()
 
     def bind_echo_routes(self):
-        # Optional: connect signals to/from UnifiedAsyncBus
-        pass
+        super().bind_echo_routes()

--- a/agents/dreamer.py
+++ b/agents/dreamer.py
@@ -7,13 +7,13 @@ class Dreamer(BaseAgent):
     invocations = ['Enter Dreamer', 'Seed dream state']
 
     def initialize_subsystem(self, core):
-        # Optional: bind to subsystem if defined
-        pass
+        """Bind to the ART controller subsystem."""
+        super().initialize_subsystem(core)
+        self.subsystem = core.get_component("art_controller")
 
     def on_gui_call(self):
         # Optional: link to GUI invocation
         super().on_gui_call()
 
     def bind_echo_routes(self):
-        # Optional: connect signals to/from UnifiedAsyncBus
-        pass
+        super().bind_echo_routes()

--- a/agents/entropybard.py
+++ b/agents/entropybard.py
@@ -7,13 +7,13 @@ class EntropyBard(BaseAgent):
     invocations = ['Sing Bard', 'Unleash entropy']
 
     def initialize_subsystem(self, core):
-        # Optional: bind to subsystem if defined
-        pass
+        """Bind to the BLT encoder subsystem."""
+        super().initialize_subsystem(core)
+        self.subsystem = core.get_component("blt_encoder")
 
     def on_gui_call(self):
         # Optional: link to GUI invocation
         super().on_gui_call()
 
     def bind_echo_routes(self):
-        # Optional: connect signals to/from UnifiedAsyncBus
-        pass
+        super().bind_echo_routes()

--- a/agents/pulsesmith.py
+++ b/agents/pulsesmith.py
@@ -7,13 +7,13 @@ class PulseSmith(BaseAgent):
     invocations = ['Tune Pulse', 'Resonate Signal']
 
     def initialize_subsystem(self, core):
-        # Optional: bind to subsystem if defined
-        pass
+        """Bind to the GridFormer subsystem."""
+        super().initialize_subsystem(core)
+        self.model = core.get_component("gridformer_connector")
 
     def on_gui_call(self):
         # Optional: link to GUI invocation
         super().on_gui_call()
 
     def bind_echo_routes(self):
-        # Optional: connect signals to/from UnifiedAsyncBus
-        pass
+        super().bind_echo_routes()

--- a/gui/gui_utils.py
+++ b/gui/gui_utils.py
@@ -1,11 +1,54 @@
+import json
 import tkinter as tk
 from typing import Optional
 
 
-def bind_agent_buttons(root: tk.Misc, registry) -> None:
+class _ToolTip:
+    """Simple tooltip for Tkinter widgets."""
+
+    def __init__(self, widget: tk.Widget, text: str) -> None:
+        self.widget = widget
+        self.text = text
+        self.tipwindow = None
+        widget.bind("<Enter>", self.show)
+        widget.bind("<Leave>", self.hide)
+
+    def show(self, _event=None) -> None:
+        if self.tipwindow or not self.text:
+            return
+        x = self.widget.winfo_rootx() + 20
+        y = self.widget.winfo_rooty() + 20
+        self.tipwindow = tw = tk.Toplevel(self.widget)
+        tw.wm_overrideredirect(True)
+        tw.geometry(f"+{x}+{y}")
+        tk.Label(
+            tw,
+            text=self.text,
+            bg="#ffffe0",
+            relief=tk.SOLID,
+            borderwidth=1,
+            font=("Consolas", 8),
+        ).pack()
+
+    def hide(self, _event=None) -> None:
+        tw = self.tipwindow
+        self.tipwindow = None
+        if tw:
+            tw.destroy()
+
+
+def bind_agent_buttons(root: tk.Misc, registry, meta_path: str = "agents.json") -> None:
     """Bind agent on_gui_call buttons to a Tkinter root or frame."""
     if not root or not registry:
         return
+
+    meta: dict[str, dict] = {}
+    try:
+        with open(meta_path, "r") as f:
+            for entry in json.load(f):
+                meta[entry.get("name")] = entry
+    except Exception:
+        meta = {}
 
     frame = tk.Frame(root, bg="#2a2a4e")
     frame.pack(side=tk.BOTTOM, fill=tk.X, pady=5)
@@ -15,9 +58,14 @@ def bind_agent_buttons(root: tk.Misc, registry) -> None:
     for agent_name, agent in registry.get_all_agents():
         if not hasattr(agent, "on_gui_call"):
             continue
+
+        meta_entry = meta.get(agent_name, {})
+        invocations = getattr(agent, "invocations", [])
+        label = invocations[0] if invocations else f"Invoke {agent_name}"
+
         btn = tk.Button(
             frame,
-            text=f"Invoke {agent_name}",
+            text=label,
             command=lambda a=agent: a.on_gui_call(),
             bg="#4ecdc4",
             fg="white",
@@ -25,4 +73,6 @@ def bind_agent_buttons(root: tk.Misc, registry) -> None:
             relief=tk.RAISED,
             bd=1,
         )
+        tooltip = f"{meta_entry.get('class', '')} | {', '.join(getattr(agent, 'tags', []))}"
+        _ToolTip(btn, tooltip)
         btn.pack(side=tk.LEFT, padx=2)


### PR DESCRIPTION
## Summary
- dynamically load all agents in `UnifiedVantaCore`
- extend `BaseAgent` with echo bindings and GUI events
- hook specific subsystems in PulseSmith, EntropyBard, Dreamer, BridgeFlesh and CodeWeaver
- enhance `gui_utils.bind_agent_buttons` with metadata and tooltips
- regenerate `agents.json` and related files

## Testing
- `python agent_validation.py`
- `pytest -q` *(fails: ImportError while importing test modules)*

------
https://chatgpt.com/codex/tasks/task_e_68473b95c46c83249b6bb178840a0ea5