### PR TITLE
Integrate HOLO mesh into Vanta core and GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,5 @@ scripts/         # Entry points and demo launchers
 
 ## HOLO-1.5 Mesh
 
-The `holo_mesh.py` module provides a lightweight scaffold for running multiple quantized LLM agents locally. Agents are loaded on demand with 4‑bit weights and optional LoRA adapters, enabling recursive conversations on resource constrained GPUs.
+The `agents/holo_mesh.py` module provides a lightweight scaffold for running multiple quantized LLM agents locally. Agents are loaded on demand with 4‑bit weights and optional LoRA adapters, enabling recursive conversations on resource constrained GPUs.
 

--- a/Vanta/core/UnifiedVantaCore.py
+++ b/Vanta/core/UnifiedVantaCore.py
@@ -58,6 +58,9 @@ from .agents import (
     VoxAgent,
     SDKContext,
     SleepTimeComputeAgent,
+    HoloMesh,
+    HOLOMeshConfig,
+    HOLOAgentConfig,
     NullAgent,
 )
 
@@ -353,6 +356,14 @@ class UnifiedVantaCore:
 
         # Map subsystems to guardian agents (Step 3 of VANTA Integration Master Plan)
         self._map_subsystems_to_guardians()
+
+        # Initialize HOLO mesh runtime loader
+        try:
+            holo_cfg = HOLOMeshConfig(agents={})
+            self.holo_mesh = HoloMesh(holo_cfg, agent_registry=self.registry)
+        except Exception as e:
+            logger.error(f"Failed to initialize HOLO mesh: {e}")
+            self.holo_mesh = None
 
 
         self.get_agents_by_capability = (

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -30,6 +30,7 @@ from .wendy import Wendy
 
 from .voxagent import VoxAgent
 from .sdkcontext import SDKContext
+from .holo_mesh import HoloMesh
 
 from .sleep_time_compute_agent import SleepTimeComputeAgent
 from .sleep_time_compute_agent import SleepTimeCompute
@@ -64,6 +65,7 @@ __all__ = [
     "Wendy",
     "VoxAgent",
     "SDKContext",
+    "HoloMesh",
     "SleepTimeComputeAgent",
     "SleepTimeCompute",
 ]

--- a/agents/holo_mesh.py
+++ b/agents/holo_mesh.py
@@ -8,7 +8,7 @@ quantization and LoRA adapter fusion.
 """
 
 from dataclasses import dataclass, field
-from typing import Dict, List
+from typing import Dict, List, Any, Callable, Coroutine
 
 import asyncio
 import logging
@@ -62,6 +62,44 @@ class HOLOAgent:
                 logger.warning("Failed to load LoRA adapter %s: %s", adapter, e)
         self.model.eval()
 
+    def on_call(self, task_input: str) -> str:
+        """Simple call handler with dynamic LoRA loading."""
+        if self.config.lora_adapters:
+            self.load_lora(self.config.lora_adapters[0])
+        output = asyncio.run(self.generate(task_input))
+        self.unload_lora()
+        return output
+
+    def load_lora(self, adapter: str) -> None:
+        """Dynamically load a LoRA adapter."""
+        if not HAVE_TRANSFORMERS:
+            return
+        try:
+            self.model = PeftModel.from_pretrained(self.model, adapter)
+            logger.info("Loaded LoRA adapter %s for %s", adapter, self.name)
+        except Exception as e:  # pragma: no cover
+            logger.warning("Failed to load LoRA adapter %s: %s", adapter, e)
+
+    def unload_lora(self) -> None:
+        """Detach all LoRA adapters from the model if possible."""
+        if not HAVE_TRANSFORMERS:
+            return
+        try:
+            base_model = getattr(self.model, "base_model", None)
+            if base_model is not None:
+                self.model = base_model
+                logger.info("Unloaded LoRA adapters for %s", self.name)
+        except Exception:
+            pass
+
+    def should_run(self) -> bool:
+        """Determine if this agent should run in the mesh loop."""
+        return True
+
+    async def run_loop(self) -> None:
+        """Placeholder run loop for the agent."""
+        await self.generate("Hello")
+
     @torch.inference_mode()
     async def generate(self, prompt: str) -> str:
         tokens = self.tokenizer(prompt, return_tensors="pt").to(self.model.device)
@@ -84,10 +122,12 @@ class HOLOMeshConfig:
 class HOLOMesh:
     """Orchestrates a mesh of lightweight LLM agents."""
 
-    def __init__(self, config: HOLOMeshConfig):
+    def __init__(self, config: HOLOMeshConfig, agent_registry: Any | None = None):
         self.config = config
         self.pool: Dict[str, HOLOAgent] = {}
         self.lock = asyncio.Lock()
+        self.agents = config.agents
+        self.agent_registry = agent_registry
 
     async def _ensure_loaded(self, name: str) -> HOLOAgent:
         async with self.lock:
@@ -112,6 +152,29 @@ class HOLOMesh:
         for name in chain:
             context = await self.ask(name, context)
         return context
+
+    def execute_all(self) -> None:
+        """Run all mesh agents sequentially if they opt in."""
+
+        async def _run():
+            for name in self.agents:
+                agent = await self._ensure_loaded(name)
+                if getattr(agent, "should_run", lambda: True)():
+                    if hasattr(agent, "run_loop"):
+                        await agent.run_loop()
+
+        asyncio.run(_run())
+
+    def route_signal(self, agent_name: str, payload: Any) -> Any:
+        """Send a payload to a specific agent."""
+
+        async def _route() -> Any:
+            agent = await self._ensure_loaded(agent_name)
+            if hasattr(agent, "handle_signal"):
+                return await agent.handle_signal(payload)
+            return await agent.generate(str(payload))
+
+        return asyncio.run(_route())
 
 
 def demo() -> None:

--- a/legacy_gui/vmb_gui_launcher.py
+++ b/legacy_gui/vmb_gui_launcher.py
@@ -363,6 +363,34 @@ class VMBGUIIntegration:
                 bd=1,
             )
             vanta_agents_btn.pack(side=tk.LEFT, padx=5)
+            # Button to run HOLO Mesh
+            holo_command = (
+                self.vanta_core.holo_mesh.execute_all
+                if self.vanta_core and getattr(self.vanta_core, "holo_mesh", None)
+                else lambda: None
+            )
+            holo_btn = tk.Button(
+                btn_frame,
+                text="🕸 Run HOLO Mesh",
+                command=holo_command,
+                bg="#8e44ad",
+                fg="white",
+                font=("Consolas", 9, "bold"),
+                relief=tk.RAISED,
+                bd=1,
+            )
+            holo_btn.pack(side=tk.LEFT, padx=5)
+            mesh_map_btn = tk.Button(
+                btn_frame,
+                text="🗺 Mesh Map",
+                command=self._on_show_holo_mesh_map,
+                bg="#34495e",
+                fg="white",
+                font=("Consolas", 9, "bold"),
+                relief=tk.RAISED,
+                bd=1,
+            )
+            mesh_map_btn.pack(side=tk.LEFT, padx=5)
 
     def _on_execute_vmb_task(self):
         """Handle VMB task execution."""
@@ -509,6 +537,19 @@ VantaCore Manager: {"✅ Initialized" if self.vanta_manager else "❌ Not initia
         except Exception as e:
             logger.error(f"Error listing agents from UnifiedVantaCore: {e}")
             messagebox.showerror("Error", f"Failed to list agents: {e}")
+
+    def _on_show_holo_mesh_map(self):
+        """Display the HOLO mesh graph file if available."""
+        try:
+            path = Path("agent_graph.json")
+            if not path.exists():
+                messagebox.showinfo("Mesh Map", "agent_graph.json not found")
+                return
+            content = path.read_text()
+            messagebox.showinfo("Mesh Map", content)
+        except Exception as e:
+            logger.error(f"Failed to load mesh map: {e}")
+            messagebox.showerror("Error", f"Failed to load mesh map: {e}")
 
     async def run(self):
         """Main run method - initializes and starts the complete system."""


### PR DESCRIPTION
## Summary
- move holo mesh implementation into `agents/` package and export
- implement LoRA load/unload and mesh control methods
- initialise HOLO mesh inside `UnifiedVantaCore`
- hook HOLO mesh controls into legacy GUI
- update README and regenerate agent validation artifacts

## Testing
- `python agent_validation.py`

------
https://chatgpt.com/codex/tasks/task_e_68475c04b30c83248d816520fd212c9c