### PR TITLE
Add BLT compression middleware and symbolic mesh

### DIFF
--- a/agents/voxagent.py
+++ b/agents/voxagent.py
@@ -1,4 +1,5 @@
 from .base import BaseAgent
+from ..blt_compression_middleware import compress_outbound
 
 
 class VoxAgent(BaseAgent):
@@ -17,3 +18,12 @@ class VoxAgent(BaseAgent):
     def bind_echo_routes(self):
         # Optional: connect signals to/from UnifiedAsyncBus
         pass
+
+    def __init__(self, vanta_core=None):
+        super().__init__(vanta_core)
+        self.outbox: list[str] = []
+
+    @compress_outbound
+    def send(self, message: str) -> None:
+        """Send a message to the outbox with BLT compression."""
+        self.outbox.append(message)

--- a/blt_compression_middleware.py
+++ b/blt_compression_middleware.py
@@ -1,0 +1,23 @@
+from functools import wraps
+from typing import Any, Callable
+
+try:
+    from VoxSigilRag.voxsigil_rag_compression import RAGCompressionEngine
+    _compressor = RAGCompressionEngine()
+except Exception:  # pragma: no cover - optional dependency
+    _compressor = None
+
+
+def compress_outbound(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Decorator to compress outbound text messages using BLT."""
+
+    @wraps(func)
+    def wrapper(self, message: Any, *args: Any, **kwargs: Any) -> Any:
+        if isinstance(message, str) and _compressor is not None:
+            try:
+                message = _compressor.compress(message) or message
+            except Exception:
+                pass
+        return func(self, message, *args, **kwargs)
+
+    return wrapper

--- a/voxsigil_mesh.py
+++ b/voxsigil_mesh.py
@@ -1,0 +1,35 @@
+"""Lightweight symbolic cognition mesh for VoxSigil."""
+from __future__ import annotations
+from typing import Any, Callable, Dict, List, Tuple
+
+from VoxSigilRag.voxsigil_rag_compression import RAGCompressionEngine
+
+
+class VoxSigilMesh:
+    """Minimal message mesh that compresses all transmissions."""
+
+    def __init__(self, gui_hook: Callable[[str], None] | None = None) -> None:
+        self.nodes: Dict[str, Any] = {}
+        self.history: List[Tuple[str, str | None]] = []
+        self.gui_hook = gui_hook
+        self.blt = RAGCompressionEngine()
+
+    def register(self, name: str, node: Any) -> None:
+        self.nodes[name] = node
+
+    def transmit(self, sender: str, message: str) -> None:
+        compressed = self.blt.compress(message)
+        self.history.append((sender, compressed))
+        if self.gui_hook:
+            try:
+                self.gui_hook(compressed)
+            except Exception:
+                pass
+        for name, node in self.nodes.items():
+            if name == sender:
+                continue
+            if hasattr(node, "receive"):
+                try:
+                    node.receive(compressed)
+                except Exception:
+                    pass


### PR DESCRIPTION
## Summary
- add `compress_outbound` decorator using RAG compression
- integrate compression in `VoxAgent` and `ExternalEchoLayer`
- add lightweight `VoxSigilMesh` implementation
- regenerate agent registry artifacts

## Testing
- `python agent_validation.py`
- `python -m py_compile blt_compression_middleware.py agents/voxagent.py external_echo_layer.py voxsigil_mesh.py`

------
https://chatgpt.com/codex/tasks/task_e_68475d206b7c83249dfb9ea04986d74c