### PR TITLE
Implement mesh echo routing and GUI panels

### DIFF
--- a/Vanta/core/UnifiedVantaCore.py
+++ b/Vanta/core/UnifiedVantaCore.py
@@ -66,6 +66,8 @@ from agents import (
     HOLOAgentConfig,
     NullAgent,
 )
+from voxsigil_mesh import VoxSigilMesh
+from vanta_mesh_graph import VantaMeshGraph
 
 # Configure logger
 logger = logging.getLogger("unified_vanta_core")
@@ -293,6 +295,8 @@ class UnifiedVantaCore:
         )  # --- ORCHESTRATION LAYER (Always Available) ---
         self.registry = ComponentRegistry()
         self.event_bus = EventBus()
+        self.mesh = VoxSigilMesh(gui_hook=lambda msg: self.event_bus.emit("mesh_echo", msg))
+        self.mesh_graph = VantaMeshGraph(self)
         self.async_bus = UnifiedAsyncBus(logger, blt_encoder)
         try:
             asyncio.create_task(self.async_bus.start())
@@ -749,6 +753,16 @@ class UnifiedVantaCore:
     ) -> None:
         """Subscribe to an event type."""
         self.event_bus.subscribe(event_type, callback, priority)
+
+    def register_mesh_node(self, name: str, node: Any) -> None:
+        """Register a node with the VoxSigilMesh."""
+        if hasattr(self, "mesh"):
+            self.mesh.register(name, node)
+
+    def send_to_mesh(self, sender: str, message: str) -> None:
+        """Transmit a message through the VoxSigilMesh."""
+        if hasattr(self, "mesh"):
+            self.mesh.transmit(sender, message)
 
     def get_system_status(self) -> Dict[str, Any]:
         """Get comprehensive system status."""

--- a/agents/sleep_time_compute_agent.py
+++ b/agents/sleep_time_compute_agent.py
@@ -1,4 +1,5 @@
 from .base import BaseAgent
+from Vanta.core.UnifiedAsyncBus import AsyncMessage, MessageType
 
 
 class SleepTimeComputeAgent(BaseAgent):
@@ -17,6 +18,21 @@ class SleepTimeComputeAgent(BaseAgent):
     def bind_echo_routes(self):
         # Optional: connect signals to/from UnifiedAsyncBus
         pass
+
+    async def run(self) -> None:
+        """Emit status and phase information via the async bus and event bus."""
+        if self.vanta_core and hasattr(self.vanta_core, "async_bus"):
+            msg = AsyncMessage(
+                MessageType.COMPONENT_STATUS,
+                self.__class__.__name__,
+                {"phase": "run"},
+            )
+            await self.vanta_core.async_bus.publish(msg)
+        if self.vanta_core and hasattr(self.vanta_core, "event_bus"):
+            self.vanta_core.event_bus.emit(
+                "sleep_time_compute.status",
+                {"phase": "run"},
+            )
 
 class SleepTimeCompute(SleepTimeComputeAgent):
     """Alias to match AGENTS.md name."""

--- a/agents/voxagent.py
+++ b/agents/voxagent.py
@@ -1,5 +1,7 @@
+import asyncio
 from .base import BaseAgent
 from ..blt_compression_middleware import compress_outbound
+from Vanta.core.UnifiedAsyncBus import AsyncMessage, MessageType
 
 
 class VoxAgent(BaseAgent):
@@ -27,3 +29,9 @@ class VoxAgent(BaseAgent):
     def send(self, message: str) -> None:
         """Send a message to the outbox with BLT compression."""
         self.outbox.append(message)
+        if self.vanta_core:
+            if hasattr(self.vanta_core, "async_bus"):
+                msg = AsyncMessage(MessageType.USER_INTERACTION, self.__class__.__name__, message)
+                asyncio.create_task(self.vanta_core.async_bus.publish(msg))
+            if hasattr(self.vanta_core, "send_to_mesh"):
+                self.vanta_core.send_to_mesh(self.__class__.__name__, message)

--- a/gui/components/echo_log_panel.py
+++ b/gui/components/echo_log_panel.py
@@ -1,0 +1,15 @@
+from PyQt5.QtWidgets import QWidget, QVBoxLayout, QPlainTextEdit
+
+class EchoLogPanel(QWidget):
+    """Simple scrolling panel that displays echo messages."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        self._box = QPlainTextEdit()
+        self._box.setReadOnly(True)
+        layout.addWidget(self._box)
+
+    def add_message(self, message: str) -> None:
+        """Append a new message to the panel."""
+        self._box.appendPlainText(message)

--- a/gui/components/mesh_map_panel.py
+++ b/gui/components/mesh_map_panel.py
@@ -1,0 +1,14 @@
+from PyQt5.QtWidgets import QWidget, QVBoxLayout, QLabel
+
+class MeshMapPanel(QWidget):
+    """Minimal panel displaying the current agent mesh graph."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.label = QLabel("No graph available")
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.label)
+
+    def refresh(self, graph: dict) -> None:
+        """Refresh panel contents with new graph data."""
+        self.label.setText(str(graph))

--- a/gui/launcher.py
+++ b/gui/launcher.py
@@ -186,7 +186,8 @@ def launch_gui_with_fallback():
     try:
         logger.info("🎨 Starting PyQt GUI main loop...")
         registry = core.agent_registry if core else None
-        pyqt_main.launch(registry)
+        event_bus = core.event_bus if core else None
+        pyqt_main.launch(registry, event_bus)
     except Exception as e:
         logger.error(f"❌ Critical error launching PyQt GUI: {e}")
         traceback.print_exc()

--- a/test_mesh_echo_chain.py
+++ b/test_mesh_echo_chain.py
@@ -1,0 +1,58 @@
+import asyncio
+import sys
+from types import SimpleNamespace, ModuleType
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
+
+# Provide dummy UnifiedAsyncBus module for agent imports
+bus_module = ModuleType('UnifiedAsyncBus')
+class MessageType:
+    USER_INTERACTION = 'user_interaction'
+    COMPONENT_STATUS = 'component_status'
+class AsyncMessage:
+    def __init__(self, *args, **kwargs):
+        self.content = args[2] if len(args) > 2 else None
+bus_module.MessageType = MessageType
+bus_module.AsyncMessage = AsyncMessage
+sys.modules['UnifiedAsyncBus'] = bus_module
+
+from agents.voxagent import VoxAgent
+from voxsigil_mesh import VoxSigilMesh
+
+
+class DummyBus:
+    def __init__(self):
+        self.publish = AsyncMock()
+
+
+class DummyEventBus:
+    def __init__(self):
+        self.events = []
+    def emit(self, event_type, data=None, **kwargs):
+        self.events.append((event_type, data))
+    def subscribe(self, *args, **kwargs):
+        pass
+
+
+class DummyCore(SimpleNamespace):
+    pass
+
+
+class MeshEchoChainTest(IsolatedAsyncioTestCase):
+    async def test_mesh_echo_chain(self):
+        core = DummyCore()
+        core.async_bus = DummyBus()
+        core.event_bus = DummyEventBus()
+        core.mesh = VoxSigilMesh(gui_hook=lambda msg: core.event_bus.emit('mesh_echo', msg))
+
+        with patch(
+            'blt_compression_middleware._compressor.compress',
+            AsyncMock(return_value='compressed'),
+        ) as mock_compress:
+            agent = VoxAgent(core)
+            agent.send('hello')
+            await asyncio.sleep(0.05)
+            mock_compress.assert_called()
+
+        core.async_bus.publish.assert_called()
+        assert any('mesh_echo' == e[0] and 'compressed' in e[1] for e in core.event_bus.events)

--- a/vanta_mesh_graph.py
+++ b/vanta_mesh_graph.py
@@ -1,0 +1,19 @@
+from typing import Any, Dict, List
+
+
+class VantaMeshGraph:
+    """Generate a simple agent graph from the live registry."""
+
+    def __init__(self, core):
+        self.core = core
+
+    def update(self) -> Dict[str, Any]:
+        """Poll live agent state and emit a graph update."""
+        agents: List[str] = []
+        if getattr(self.core, "agent_registry", None):
+            agents = [name for name, _ in self.core.agent_registry.get_all_agents()]
+        edges = [{"from": name, "to": "UnifiedVantaCore"} for name in agents]
+        graph = {"agents": agents, "edges": edges}
+        if getattr(self.core, "event_bus", None):
+            self.core.event_bus.emit("mesh_graph_update", graph)
+        return graph


### PR DESCRIPTION
## Summary
- integrate VoxSigilMesh with UnifiedVantaCore and expose send_to_mesh
- update VoxAgent to publish via async bus and mesh
- add EchoLogPanel and MeshMapPanel to PyQt GUI
- pass event bus into GUI launcher
- implement status events for SleepTimeComputeAgent
- provide simple VantaMeshGraph helper
- add test covering mesh echo chain
- regenerate agent reports

## Testing
- `python agent_validation.py`
- `pytest test_mesh_echo_chain.py -q` *(fails: ImportError due to package layout)*

------
https://chatgpt.com/codex/tasks/task_e_6847665aad348324a744f7916e9cdbff