### PR TITLE
Implement agent import fallbacks and GUI status panel

### DIFF
--- a/agent_validation.py
+++ b/agent_validation.py
@@ -30,10 +30,16 @@ for line in MANIFEST_FILE.read_text().splitlines():
 
 available_modules = {}
 for line in (AGENT_DIR / "__init__.py").read_text().splitlines():
-    m = re.match(r"from \.([a-zA-Z0-9_]+) import (\w+)", line)
+    m = re.search(
+        r"from \.([a-zA-Z0-9_]+) import (\w+)|_import_agent\([\"']([a-zA-Z0-9_]+)[\"']\s*,\s*[\"']([a-zA-Z0-9_]+)[\"']\)",
+        line,
+    )
     if m:
-        module, cls = m.groups()
-        available_modules[cls] = f"agents.{module}"
+        groups = [g for g in m.groups() if g]
+        if len(groups) >= 2:
+            module = groups[0] or groups[2]
+            cls = groups[1] or groups[3]
+            available_modules[cls] = f"agents.{module}"
 
 log_lines = []
 registered = []
@@ -52,6 +58,12 @@ for entry in agents:
     exists = bool(module)
     imported = module is not None and Path(AGENT_DIR / (module.split('.')[-1] + '.py')).exists()
     reg = cls_name in registered
+    stub = False
+    file_path = AGENT_DIR / f"{module.split('.')[-1]}.py" if module else None
+    if file_path and file_path.exists():
+        text = file_path.read_text()
+        if "def run" not in text:
+            stub = True
     data.append({
         "name": cls_name,
         "sigil": entry["sigil"],
@@ -60,6 +72,7 @@ for entry in agents:
         "sub_agents": entry["subagents"],
         "status": "registered" if reg else "missing",
         "dependencies": [module] if module else [],
+        "stub": stub,
     })
     if not exists:
         log_lines.append(f"Module for agent {cls_name} missing")
@@ -67,6 +80,8 @@ for entry in agents:
         log_lines.append(f"Agent file not importable for {cls_name}")
     if not reg:
         log_lines.append(f"Agent {cls_name} not registered in VantaCore")
+    if stub:
+        log_lines.append(f"Agent {cls_name} missing run() implementation")
 
 Path("agents.json").write_text(json.dumps(data, indent=2))
 

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,43 +1,76 @@
+"""Agent package with import fallbacks and status logging."""
+
+from __future__ import annotations
+
+import logging
+from importlib import import_module
+from pathlib import Path
+
 from .base import BaseAgent, NullAgent
 
-from .phi import Phi
-from .voxka import Voxka
-from .gizmo import Gizmo
-from .nix import Nix
-from .echo import Echo
-from .oracle import Oracle
-from .astra import Astra
-from .warden import Warden
-from .nebula import Nebula
-from .orion import Orion
-from .evo import Evo
 
-from .orionapprentice import OrionApprentice
-from .socraticengine import SocraticEngine
-from .dreamer import Dreamer
-from .entropybard import EntropyBard
-from .codeweaver import CodeWeaver
-from .echolore import EchoLore
-from .mirrorwarden import MirrorWarden
-from .pulsesmith import PulseSmith
-from .bridgeflesh import BridgeFlesh
+logger = logging.getLogger(__name__)
+_STATUS_FILE = Path(__file__).resolve().parent.parent / "agent_status.log"
+_status_lines: list[str] = []
 
-from .sam import Sam
-from .dave import Dave
-from .carla import Carla
-from .andy import Andy
-from .wendy import Wendy
 
-from .voxagent import VoxAgent
-from .sdkcontext import SDKContext
-from .holo_mesh import HoloMesh
+def _import_agent(module_name: str, class_name: str) -> type[BaseAgent]:
+    try:
+        module = import_module(f".{{module_name}}", __name__)
+        cls = getattr(module, class_name)
+        _status_lines.append(f"✅ Registered: {class_name}")
+        return cls
+    except Exception as exc:  # pragma: no cover - optional agents
+        logger.warning("Failed to import %s: %s", class_name, exc)
+        _status_lines.append(f"❌ Failed: {class_name}")
+        return type(class_name, (NullAgent,), {})
+
+
+Phi = _import_agent("phi", "Phi")
+Voxka = _import_agent("voxka", "Voxka")
+Gizmo = _import_agent("gizmo", "Gizmo")
+Nix = _import_agent("nix", "Nix")
+Echo = _import_agent("echo", "Echo")
+Oracle = _import_agent("oracle", "Oracle")
+Astra = _import_agent("astra", "Astra")
+Warden = _import_agent("warden", "Warden")
+Nebula = _import_agent("nebula", "Nebula")
+Orion = _import_agent("orion", "Orion")
+Evo = _import_agent("evo", "Evo")
+
+OrionApprentice = _import_agent("orionapprentice", "OrionApprentice")
+SocraticEngine = _import_agent("socraticengine", "SocraticEngine")
+Dreamer = _import_agent("dreamer", "Dreamer")
+EntropyBard = _import_agent("entropybard", "EntropyBard")
+CodeWeaver = _import_agent("codeweaver", "CodeWeaver")
+EchoLore = _import_agent("echolore", "EchoLore")
+MirrorWarden = _import_agent("mirrorwarden", "MirrorWarden")
+PulseSmith = _import_agent("pulsesmith", "PulseSmith")
+BridgeFlesh = _import_agent("bridgeflesh", "BridgeFlesh")
+
+Sam = _import_agent("sam", "Sam")
+Dave = _import_agent("dave", "Dave")
+Carla = _import_agent("carla", "Carla")
+Andy = _import_agent("andy", "Andy")
+Wendy = _import_agent("wendy", "Wendy")
+
+VoxAgent = _import_agent("voxagent", "VoxAgent")
+SDKContext = _import_agent("sdkcontext", "SDKContext")
+HoloMesh = _import_agent("holo_mesh", "HoloMesh")
 
 # 🧠 Codex BugPatch - Vanta Phase @2025-06-09
 # SleepTimeCompute is an alias to SleepTimeComputeAgent. Having both exported
 # may lead to duplicate agent entries if not handled. Kept for manifest
 # compatibility.
-from .sleep_time_compute_agent import SleepTimeComputeAgent
-from .sleep_time_compute_agent import SleepTimeCompute
+SleepTimeComputeAgent = _import_agent(
+    "sleep_time_compute_agent", "SleepTimeComputeAgent"
+)
+SleepTimeCompute = _import_agent("sleep_time_compute_agent", "SleepTimeCompute")
+
+try:
+    _STATUS_FILE.write_text("\n".join(_status_lines) + "\n")
+except Exception as exc:  # pragma: no cover - logging only
+    logger.warning("Failed to write agent status: %s", exc)
 
 __all__ = [
     "BaseAgent",

--- a/agents/base.py
+++ b/agents/base.py
@@ -2,7 +2,7 @@
 import logging
 import asyncio
 
-from ..UnifiedAsyncBus import AsyncMessage, MessageType
+from Vanta.core.UnifiedAsyncBus import AsyncMessage, MessageType
 
 
 logger = logging.getLogger(__name__)

--- a/agents/voxagent.py
+++ b/agents/voxagent.py
@@ -35,3 +35,7 @@ class VoxAgent(BaseAgent):
                 asyncio.create_task(self.vanta_core.async_bus.publish(msg))
             if hasattr(self.vanta_core, "send_to_mesh"):
                 self.vanta_core.send_to_mesh(self.__class__.__name__, message)
+
+    def respond(self) -> str:
+        """Return the last sent message."""
+        return self.outbox[-1] if self.outbox else ""

--- a/gui/components/agent_status_panel.py
+++ b/gui/components/agent_status_panel.py
@@ -1,8 +1,9 @@
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QPlainTextEdit
 from PyQt5.QtGui import QTextCursor
 
-class EchoLogPanel(QWidget):
-    """Simple scrolling panel that displays echo messages."""
+
+class AgentStatusPanel(QWidget):
+    """Panel showing agent import and runtime status."""
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -11,7 +12,7 @@ class EchoLogPanel(QWidget):
         self._box.setReadOnly(True)
         layout.addWidget(self._box)
 
-    def add_message(self, message: str) -> None:
-        """Append a new message to the panel."""
-        self._box.appendPlainText(message)
+    def add_status(self, text: str) -> None:
+        self._box.appendPlainText(text)
         self._box.moveCursor(QTextCursor.End)
+

--- a/gui/components/mesh_map_panel.py
+++ b/gui/components/mesh_map_panel.py
@@ -1,4 +1,5 @@
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QLabel
+from PyQt5.QtCore import Qt
 
 class MeshMapPanel(QWidget):
     """Minimal panel displaying the current agent mesh graph."""
@@ -11,4 +12,12 @@ class MeshMapPanel(QWidget):
 
     def refresh(self, graph: dict) -> None:
         """Refresh panel contents with new graph data."""
-        self.label.setText(str(graph))
+        if not graph:
+            self.label.setText("No graph available")
+            return
+        lines = []
+        agents = graph.get("agents", {})
+        for name, color in agents.items():
+            lines.append(f'<span style="color:{color}">{name}</span>')
+        self.label.setText("<br>".join(lines))
+        self.label.setAlignment(Qt.AlignTop)

--- a/gui/components/pyqt_main.py
+++ b/gui/components/pyqt_main.py
@@ -14,23 +14,39 @@ from PyQt5.QtWidgets import (
 
 from .echo_log_panel import EchoLogPanel
 from .mesh_map_panel import MeshMapPanel
+from .agent_status_panel import AgentStatusPanel
 
 
 class VoxSigilMainWindow(QMainWindow):
     """Simplified PyQt main window with placeholder tabs."""
 
-    def __init__(self, registry=None, event_bus=None):
+    def __init__(self, registry=None, event_bus=None, async_bus=None):
         super().__init__()
         self.registry = registry
         self.event_bus = event_bus
+        self.async_bus = async_bus
         self.echo_panel = None
         self.mesh_map_panel = None
+        self.status_panel = None
         self.setWindowTitle("VoxSigil PyQt GUI")
         self.resize(1000, 800)
         self._init_ui()
         if self.event_bus:
             self.event_bus.subscribe("mesh_echo", self._on_mesh_echo)
             self.event_bus.subscribe("mesh_graph_update", self._on_mesh_graph)
+            self.event_bus.subscribe("agent_status", self._on_status)
+        if self.async_bus:
+            try:
+                self.async_bus.register_component("GUI")
+                from Vanta.core.UnifiedAsyncBus import MessageType, AsyncMessage
+
+                def _echo_cb(msg: AsyncMessage):
+                    if self.echo_panel:
+                        self.echo_panel.add_message(str(msg.content))
+
+                self.async_bus.subscribe("GUI", MessageType.USER_INTERACTION, _echo_cb)
+            except Exception:
+                pass
 
     def _init_ui(self):
         tabs = QTabWidget()
@@ -41,8 +57,10 @@ class VoxSigilMainWindow(QMainWindow):
         tabs.addTab(self._create_placeholder_tab("Performance"), "Performance")
         self.echo_panel = EchoLogPanel()
         self.mesh_map_panel = MeshMapPanel()
+        self.status_panel = AgentStatusPanel()
         tabs.addTab(self.echo_panel, "Echo Log")
         tabs.addTab(self.mesh_map_panel, "Mesh Map")
+        tabs.addTab(self.status_panel, "Agent Status")
         container = QWidget()
         layout = QVBoxLayout(container)
         layout.addWidget(tabs)
@@ -86,10 +104,16 @@ class VoxSigilMainWindow(QMainWindow):
             if graph is not None:
                 self.mesh_map_panel.refresh(graph)
 
+    def _on_status(self, event):
+        if self.status_panel:
+            msg = event.get("data")
+            if msg:
+                self.status_panel.add_status(str(msg))
 
-def launch(registry=None, event_bus=None):
+
+def launch(registry=None, event_bus=None, async_bus=None):
     app = QApplication(sys.argv)
-    win = VoxSigilMainWindow(registry, event_bus)
+    win = VoxSigilMainWindow(registry, event_bus, async_bus)
     win.show()
     return app.exec_()
 

--- a/gui/launcher.py
+++ b/gui/launcher.py
@@ -187,7 +187,8 @@ def launch_gui_with_fallback():
         logger.info("🎨 Starting PyQt GUI main loop...")
         registry = core.agent_registry if core else None
         event_bus = core.event_bus if core else None
-        pyqt_main.launch(registry, event_bus)
+        async_bus = core.async_bus if core else None
+        pyqt_main.launch(registry, event_bus, async_bus)
     except Exception as e:
         logger.error(f"❌ Critical error launching PyQt GUI: {e}")
         traceback.print_exc()

--- a/test/test_mesh_echo_chain.py
+++ b/test/test_mesh_echo_chain.py
@@ -1,0 +1,66 @@
+import asyncio
+import sys
+import os
+from types import SimpleNamespace, ModuleType
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
+
+# Provide dummy UnifiedAsyncBus module for agent imports
+bus_module = ModuleType('UnifiedAsyncBus')
+class MessageType:
+    USER_INTERACTION = 'user_interaction'
+    COMPONENT_STATUS = 'component_status'
+class AsyncMessage:
+    def __init__(self, *args, **kwargs):
+        self.content = args[2] if len(args) > 2 else None
+bus_module.MessageType = MessageType
+bus_module.AsyncMessage = AsyncMessage
+sys.modules['UnifiedAsyncBus'] = bus_module
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from agents.voxagent import VoxAgent
+from voxsigil_mesh import VoxSigilMesh
+
+
+class DummyBus:
+    def __init__(self):
+        self.publish = AsyncMock()
+
+
+class DummyEventBus:
+    def __init__(self):
+        self.events = []
+    def emit(self, event_type, data=None, **kwargs):
+        self.events.append((event_type, data))
+    def subscribe(self, *args, **kwargs):
+        pass
+
+
+class DummyCore(SimpleNamespace):
+    pass
+
+
+class MeshEchoChainTest(IsolatedAsyncioTestCase):
+    async def test_mesh_echo_chain(self):
+        core = DummyCore()
+        core.async_bus = DummyBus()
+        core.event_bus = DummyEventBus()
+        core.mesh = VoxSigilMesh(gui_hook=lambda msg: core.event_bus.emit('mesh_echo', msg))
+        core.mesh.register('A', SimpleNamespace(receive=AsyncMock()))
+        core.mesh.register('B', SimpleNamespace(receive=AsyncMock()))
+        core.mesh.register('Logger', SimpleNamespace(receive=AsyncMock()))
+
+        with patch(
+            'blt_compression_middleware._compressor.compress',
+            AsyncMock(return_value='compressed'),
+        ) as mock_compress:
+            agent = VoxAgent(core)
+            agent.send('hello')
+            await asyncio.sleep(0.05)
+            mock_compress.assert_called()
+
+        core.mesh.test_broadcast()
+
+        core.async_bus.publish.assert_called()
+        assert any('mesh_echo' == e[0] and 'compressed' in e[1] for e in core.event_bus.events)

--- a/voxsigil_mesh.py
+++ b/voxsigil_mesh.py
@@ -33,3 +33,13 @@ class VoxSigilMesh:
                     node.receive(compressed)
                 except Exception:
                     pass
+
+    # --- Convenience methods -------------------------------------------------
+
+    def broadcast(self, sender: str, message: str) -> None:
+        """Alias for transmit for backwards compatibility."""
+        self.transmit(sender, message)
+
+    def test_broadcast(self, msg: str = "⚡ TEST_SIGNAL") -> None:
+        """Emit a test signal to all registered nodes."""
+        self.broadcast("Tester", msg)


### PR DESCRIPTION
## Summary
- add dynamic agent loading with status logging
- provide AgentStatusPanel and auto-scroll EchoLogPanel
- color-code mesh map output
- pass async bus to GUI and hook message callbacks
- add test mesh broadcast and broadcast helpers

## Testing
- `python agent_validation.py`
- `python -m unittest discover -s test -v` *(fails: ModuleNotFoundError: No module named 'Vanta.interfaces')*

------
https://chatgpt.com/codex/tasks/task_e_68476af7dd2483248b1cdf62b28402b5