### PR TITLE
Fix BLT bridge import

### DIFF
--- a/ART/blt/art_blt_bridge.py
+++ b/ART/blt/art_blt_bridge.py
@@ -14,8 +14,10 @@ from ..art_logger import get_art_logger
 
 # Try to import BLT components - only importing what we need
 try:
-    # Only import the SigilPatchEncoder which is actually used in this module
-    from BLT.sigil_patch_encoder import SigilPatchEncoder
+    # SigilPatchEncoder now lives in the BLT package __init__ to avoid
+    # circular import issues. Import directly from BLT so the bridge can
+    # locate the class whether BLT is installed as a package or in-tree.
+    from BLT import SigilPatchEncoder
 
     # Set flag that BLT is available
     HAS_BLT = True

--- a/agent_status.log
+++ b/agent_status.log
@@ -1,29 +1,56 @@
 UnifiedVantaCore import failed: No module named 'jsonschema'
 Agent Phi not registered in VantaCore
+Agent Phi missing run() implementation
 Agent Voxka not registered in VantaCore
+Agent Voxka missing run() implementation
 Agent Gizmo not registered in VantaCore
+Agent Gizmo missing run() implementation
 Agent Nix not registered in VantaCore
+Agent Nix missing run() implementation
 Agent Echo not registered in VantaCore
+Agent Echo missing run() implementation
 Agent Oracle not registered in VantaCore
+Agent Oracle missing run() implementation
 Agent Astra not registered in VantaCore
+Agent Astra missing run() implementation
 Agent Warden not registered in VantaCore
+Agent Warden missing run() implementation
 Agent Nebula not registered in VantaCore
+Agent Nebula missing run() implementation
 Agent Orion not registered in VantaCore
+Agent Orion missing run() implementation
 Agent Evo not registered in VantaCore
+Agent Evo missing run() implementation
 Agent OrionApprentice not registered in VantaCore
+Agent OrionApprentice missing run() implementation
 Agent SocraticEngine not registered in VantaCore
+Agent SocraticEngine missing run() implementation
 Agent Dreamer not registered in VantaCore
+Agent Dreamer missing run() implementation
 Agent EntropyBard not registered in VantaCore
+Agent EntropyBard missing run() implementation
 Agent CodeWeaver not registered in VantaCore
+Agent CodeWeaver missing run() implementation
 Agent EchoLore not registered in VantaCore
+Agent EchoLore missing run() implementation
 Agent MirrorWarden not registered in VantaCore
+Agent MirrorWarden missing run() implementation
 Agent PulseSmith not registered in VantaCore
+Agent PulseSmith missing run() implementation
 Agent BridgeFlesh not registered in VantaCore
+Agent BridgeFlesh missing run() implementation
 Agent Sam not registered in VantaCore
+Agent Sam missing run() implementation
 Agent Dave not registered in VantaCore
+Agent Dave missing run() implementation
 Agent Carla not registered in VantaCore
+Agent Carla missing run() implementation
 Agent Andy not registered in VantaCore
+Agent Andy missing run() implementation
 Agent Wendy not registered in VantaCore
+Agent Wendy missing run() implementation
 Agent VoxAgent not registered in VantaCore
+Agent VoxAgent missing run() implementation
 Agent SDKContext not registered in VantaCore
+Agent SDKContext missing run() implementation
 Agent SleepTimeCompute not registered in VantaCore

--- a/agents.json
+++ b/agents.json
@@ -8,7 +8,8 @@
     "status": "missing",
     "dependencies": [
       "agents.phi"
-    ]
+    ],
+    "stub": true
   },
   {
     "name": "Voxka",
@@ -22,7 +23,8 @@
     "status": "missing",
     "dependencies": [
       "agents.voxka"
-    ]
+    ],
+    "stub": true
   },
   {
     "name": "Gizmo",
@@ -36,7 +38,8 @@
     "status": "missing",
     "dependencies": [
       "agents.gizmo"
-    ]
+    ],
+    "stub": true
   },
   {
     "name": "Nix",
@@ -50,7 +53,8 @@
     "status": "missing",
     "dependencies": [
       "agents.nix"
-    ]
+    ],
+    "stub": true
   },
   {
     "name": "Echo",
@@ -64,7 +68,8 @@
     "status": "missing",
     "dependencies": [
       "agents.echo"
-    ]
+    ],
+    "stub": true
   },
   {
     "name": "Oracle",
@@ -78,7 +83,8 @@
     "status": "missing",
     "dependencies": [
       "agents.oracle"
-    ]
+    ],
+    "stub": true
   },
   {
     "name": "Astra",
@@ -92,7 +98,8 @@
     "status": "missing",
     "dependencies": [
       "agents.astra"
-    ]
+    ],
+    "stub": true
   },
   {
     "name": "Warden",
@@ -106,7 +113,8 @@
     "status": "missing",
     "dependencies": [
       "agents.warden"
-    ]
+    ],
+    "stub": true
   },
   {
     "name": "Nebula",
@@ -120,7 +128,8 @@
     "status": "missing",
     "dependencies": [
       "agents.nebula"
-    ]
+    ],
+    "stub": true
   },
   {
     "name": "Orion",
@@ -134,7 +143,8 @@
     "status": "missing",
     "dependencies": [
       "agents.orion"
-    ]
+    ],
+    "stub": true
   },
   {
     "name": "Evo",
@@ -145,7 +155,8 @@
     "status": "missing",
     "dependencies": [
       "agents.evo"
-    ]
+    ],
+    "stub": true
   },
   {
     "name": "OrionApprentice",
@@ -156,7 +167,8 @@
     "status": "missing",
     "dependencies": [
       "agents.orionapprentice"
-    ]
+    ],
+    "stub": true
   },
   {
     "name": "SocraticEngine",
@@ -167,7 +179,8 @@
     "status": "missing",
     "dependencies": [
       "agents.socraticengine"
-    ]
+    ],
+    "stub": true
   },
   {
     "name": "Dreamer",
@@ -178,7 +191,8 @@
     "status": "missing",
     "dependencies": [
       "agents.dreamer"
-    ]
+    ],
+    "stub": true
   },
   {
     "name": "EntropyBard",
@@ -189,7 +203,8 @@
     "status": "missing",
     "dependencies": [
       "agents.entropybard"
-    ]
+    ],
+    "stub": true
   },
   {
     "name": "CodeWeaver",
@@ -200,7 +215,8 @@
     "status": "missing",
     "dependencies": [
       "agents.codeweaver"
-    ]
+    ],
+    "stub": true
   },
   {
     "name": "EchoLore",
@@ -211,7 +227,8 @@
     "status": "missing",
     "dependencies": [
       "agents.echolore"
-    ]
+    ],
+    "stub": true
   },
   {
     "name": "MirrorWarden",
@@ -222,7 +239,8 @@
     "status": "missing",
     "dependencies": [
       "agents.mirrorwarden"
-    ]
+    ],
+    "stub": true
   },
   {
     "name": "PulseSmith",
@@ -233,7 +251,8 @@
     "status": "missing",
     "dependencies": [
       "agents.pulsesmith"
-    ]
+    ],
+    "stub": true
   },
   {
     "name": "BridgeFlesh",
@@ -244,7 +263,8 @@
     "status": "missing",
     "dependencies": [
       "agents.bridgeflesh"
-    ]
+    ],
+    "stub": true
   },
   {
     "name": "Sam",
@@ -255,7 +275,8 @@
     "status": "missing",
     "dependencies": [
       "agents.sam"
-    ]
+    ],
+    "stub": true
   },
   {
     "name": "Dave",
@@ -266,7 +287,8 @@
     "status": "missing",
     "dependencies": [
       "agents.dave"
-    ]
+    ],
+    "stub": true
   },
   {
     "name": "Carla",
@@ -277,7 +299,8 @@
     "status": "missing",
     "dependencies": [
       "agents.carla"
-    ]
+    ],
+    "stub": true
   },
   {
     "name": "Andy",
@@ -288,7 +311,8 @@
     "status": "missing",
     "dependencies": [
       "agents.andy"
-    ]
+    ],
+    "stub": true
   },
   {
     "name": "Wendy",
@@ -299,7 +323,8 @@
     "status": "missing",
     "dependencies": [
       "agents.wendy"
-    ]
+    ],
+    "stub": true
   },
   {
     "name": "VoxAgent",
@@ -312,7 +337,8 @@
     "status": "missing",
     "dependencies": [
       "agents.voxagent"
-    ]
+    ],
+    "stub": true
   },
   {
     "name": "SDKContext",
@@ -323,7 +349,8 @@
     "status": "missing",
     "dependencies": [
       "agents.sdkcontext"
-    ]
+    ],
+    "stub": true
   },
   {
     "name": "SleepTimeCompute",
@@ -334,6 +361,7 @@
     "status": "missing",
     "dependencies": [
       "agents.sleep_time_compute_agent"
-    ]
+    ],
+    "stub": false
   }
 ]


### PR DESCRIPTION
## Summary
- fix incorrect import path for `SigilPatchEncoder`
- regenerate agent validation artifacts

## Testing
- `python agent_validation.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'Vanta.interfaces')*

------
https://chatgpt.com/codex/tasks/task_e_684788522c688324b0e3304c82a46fa6