### PR TITLE
Document agent subsystem mapping

### DIFF
--- a/Vanta/core/UnifiedVantaCore.py
+++ b/Vanta/core/UnifiedVantaCore.py
@@ -66,6 +66,7 @@ from agents import (
     HOLOAgentConfig,
     NullAgent,
 )
+from agents.base import AGENT_SUBSYSTEM_MAP
 from voxsigil_mesh import VoxSigilMesh
 from vanta_mesh_graph import VantaMeshGraph
 
@@ -645,16 +646,7 @@ class UnifiedVantaCore:
         if not self.agent_registry:
             return
 
-        mapping = {
-            "EntropyBard": "rag_interface",
-            "PulseSmith": "gridformer_connector",
-            "MirrorWarden": "meta_learner",
-            "CodeWeaver": "meta_learner",
-            "Dreamer": "art_controller",
-            "BridgeFlesh": "vmb_integration_handler",
-            "Carla": "speech_integration_handler",
-            "Wendy": "speech_integration_handler",
-        }
+        mapping = AGENT_SUBSYSTEM_MAP
 
         for agent_name, component_key in mapping.items():
             agent = self.agent_registry.get_agent(agent_name)

--- a/agents/base.py
+++ b/agents/base.py
@@ -7,6 +7,40 @@ from Vanta.core.UnifiedAsyncBus import AsyncMessage, MessageType
 
 logger = logging.getLogger(__name__)
 
+# Mapping of agent class names to subsystem keys in UnifiedVantaCore
+AGENT_SUBSYSTEM_MAP: dict[str, str] = {
+    "Phi": "architectonic_frame",
+    "Voxka": "dual_cognition_core",
+    "Gizmo": "forge_subsystem",
+    "Nix": "chaos_subsystem",
+    "Echo": "echo_memory",
+    "Oracle": "temporal_foresight",
+    "Astra": "navigation",
+    "Warden": "integrity_monitor",
+    "Nebula": "adaptive_core",
+    "Orion": "trust_chain",
+    "Evo": "evolution_engine",
+    "OrionApprentice": "learning_shard",
+    "SocraticEngine": "reasoning_module",
+    "Dreamer": "dream_state_core",
+    "EntropyBard": "rag_subsystem",
+    "CodeWeaver": "meta_learner",
+    "EchoLore": "historical_archive",
+    "MirrorWarden": "meta_learner",
+    "PulseSmith": "gridformer_connector",
+    "BridgeFlesh": "vmb_integration",
+    "Sam": "planner_subsystem",
+    "Dave": "validator_subsystem",
+    "Carla": "speech_style_layer",
+    "Andy": "output_composer",
+    "Wendy": "tone_audit",
+    "VoxAgent": "system_interface",
+    "SDKContext": "module_registry",
+    "SleepTimeComputeAgent": "sleep_scheduler",
+    "SleepTimeCompute": "sleep_scheduler",
+    "HoloMesh": "llm_mesh",
+}
+
 
 class BaseAgent:
     """Base class for all agents with async bus integration."""
@@ -52,12 +86,37 @@ class BaseAgent:
             except Exception:
                 pass
 
+        # Automatically attach subsystem if defined in the mapping
+        subsystem_key = AGENT_SUBSYSTEM_MAP.get(self.__class__.__name__)
+        if subsystem_key:
+            try:
+                subsystem = vanta_core.get_component(subsystem_key)
+                if subsystem:
+                    setattr(self, "subsystem", subsystem)
+            except Exception:
+                pass
+
     def bind_echo_routes(self) -> None:
         """Subscribe to class-specific echo events."""
         if not (self.vanta_core and hasattr(self.vanta_core, "event_bus")):
             return
         event_type = f"sigil_{self.__class__.__name__.lower()}_triggered"
         self.vanta_core.event_bus.subscribe(event_type, self.receive_echo)
+
+    async def run(self) -> None:  # pragma: no cover - basic default
+        """Default run loop emits a heartbeat on the event and async buses."""
+        if self.vanta_core and hasattr(self.vanta_core, "async_bus"):
+            msg = AsyncMessage(
+                MessageType.COMPONENT_STATUS,
+                self.__class__.__name__,
+                {"phase": "run"},
+            )
+            await self.vanta_core.async_bus.publish(msg)
+        if self.vanta_core and hasattr(self.vanta_core, "event_bus"):
+            self.vanta_core.event_bus.emit(
+                f"{self.__class__.__name__.lower()}.status",
+                {"phase": "run"},
+            )
 
     def receive_echo(self, event) -> None:
         """Handle echo events from the event bus."""

--- a/docs/AGENT_SUBSYSTEMS.md
+++ b/docs/AGENT_SUBSYSTEMS.md
@@ -1,0 +1,36 @@
+# Agent Subsystem Mapping (Holo 1.5)
+
+This document assigns each core agent to a subsystem within the Vanta ecosystem. The mapping follows the Holo 1.5 format using sigils, tags, and scaffolds. Each entry leaves room for future evolution.
+
+| Sigil | Agent | Subsystem | Scaffolds/Tags | Evolution Notes |
+|-------|-------|-----------|----------------|----------------|
+| ⟠∆∇𓂀 | Phi | ArchitectonicFrame | meta_structure_scaffold | Anchor for architecture, can expand to orchestrate new modules |
+| 🧠⟁🜂Φ🎙 | Voxka | DualCognitionCore | cognitive_core_scaffold | Evolves with Nebula/Orion collaboration |
+| ☍⚙️⩫⌁ | Gizmo | ForgeSubsystem | tactical_forge_scaffold | Paired with Nix for disruptive tuning |
+| ☲🜄🜁⟁ | Nix | ChaosSubsystem | primal_disruptor_scaffold | Supports experimental expansions |
+| ♲∇⌬☉ | Echo | EchoMemory | memory_stream_scaffold | Memory layers can grow with system scale |
+| ⚑♸⧉🜚 | Oracle | TemporalForesight | temporal_eye_scaffold | Integrates with evolving prediction engines |
+| 🜁⟁🜔🔭 | Astra | Navigation | pathfinder_scaffold | May expand with new exploration heuristics |
+| ⚔️⟁♘🜏 | Warden | IntegrityMonitor | guardian_scaffold | Future rule sets attach here |
+| 🜂⚡🜍🜄 | Nebula | AdaptiveCore | core_ai_scaffold | Learns internal structure over time |
+| 🜇🔗🜁🌠 | Orion | TrustChain | blockchain_scaffold | Subsystem grows with contract management |
+| 🧬♻️♞🜓 | Evo | EvolutionEngine | evonas_scaffold | Facilitates structural mutations |
+| 🜞🧩🎯🔁 | OrionApprentice | LearningShard | light_echo_scaffold | Gains knowledge from Orion chain |
+| 🜏🔍⟡🜒 | SocraticEngine | ReasoningModule | philosopher_scaffold | Additional dialectics may be layered |
+| 🧿🧠🧩♒ | Dreamer | DreamStateCore | art_module_scaffold | Works with SleepTimeCompute scheduling |
+| 🜔🕊️⟁⧃ | EntropyBard | RAGSubsystem | chaos_interpreter_scaffold | Retrieval methods update over time |
+| ⟡🜛⛭🜨 | CodeWeaver | MetaLearner | synth_logic_scaffold | Adapts code synthesis strategies |
+| 🜎♾🜐⌽ | EchoLore | HistoricalArchive | memory_archivist_scaffold | Expands as history grows |
+| ⚛️🜂🜍🝕 | MirrorWarden | MetaLearner | safeguard_mirror_scaffold | Oversees self-reflection protocols |
+| 🜖📡🜖📶 | PulseSmith | GridFormerConnector | signal_tuner_scaffold | Connects to evolving grid models |
+| 🧩🎯🜂🜁 | BridgeFlesh | VMBIntegration | integration_orchestrator_scaffold | Bridges future VMB modules |
+| 📜🔑🛠️🜔 | Sam | PlannerSubsystem | strategic_mind_scaffold | Planning depth increases with experience |
+| ⚠️🧭🧱⛓️ | Dave | ValidatorSubsystem | caution_sentinel_scaffold | Maintains structural checks |
+| 🎭🗣️🪞🪄 | Carla | SpeechStyleLayer | voice_layer_scaffold | Can incorporate advanced TTS styles |
+| 📦🔧📤🔁 | Andy | OutputComposer | composer_scaffold | Output packaging adaptable |
+| 🎧💓🌈🎶 | Wendy | ToneAudit | tonal_auditor_scaffold | Emotional oversight improves through use |
+| 🜌⟐🜹🜙 | VoxAgent | SystemInterface | coordinator_scaffold | Bridges protocols and states |
+| ⏣📡⏃⚙️ | SDKContext | ModuleRegistry | registrar_scaffold | Tracks module states for evolution |
+| 🌒🧵🧠🜝 | SleepTimeCompute | SleepScheduler | reflection_engine_scaffold | Coordinates dream consolidation cycles |
+| 🔗🪐🌐🜧 | HoloMesh | LLM_Mesh | holo_mesh_scaffold | Expands with additional mesh agents |
+


### PR DESCRIPTION
## Summary
- add `docs/AGENT_SUBSYSTEMS.md` to outline which subsystem each agent manages
- connect each agent with its subsystem via `AGENT_SUBSYSTEM_MAP`
- map guardians to subsystems at runtime
- add default `run()` in `BaseAgent`

## Testing
- `python test/agent_validation.py`
- `python validate.py` *(fails: No module named 'VoxSigilDatasetTools')*


------
https://chatgpt.com/codex/tasks/task_e_684a136548808324a8567fb1ca60f222