### PR TITLE
Fix interface imports and add missing stubs

### DIFF
--- a/BLT/__init__.py
+++ b/BLT/__init__.py
@@ -13,9 +13,24 @@ import re
 import time
 from typing import Any, Dict, List, Optional, Tuple
 
-import jsonschema
-import numpy as np
-from jsonschema import SchemaError, ValidationError
+try:
+    import jsonschema
+    from jsonschema import SchemaError, ValidationError
+except ImportError:  # pragma: no cover - optional dependency
+    jsonschema = None
+    SchemaError = None
+    ValidationError = None
+    logging.getLogger(__name__).warning(
+        "jsonschema library not installed. Schema validation disabled"
+    )
+
+try:
+    import numpy as np
+except ImportError:  # pragma: no cover - optional dependency
+    np = None
+    logging.getLogger(__name__).warning(
+        "numpy not installed. Some BLTEncoder features will be limited"
+    )
 
 # Try to import the interface, but don't fail if it's not available
 try:

--- a/BLT/hybrid_blt.py
+++ b/BLT/hybrid_blt.py
@@ -29,7 +29,8 @@ from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings
 
 from . import ByteLatentTransformerEncoder, SigilPatchEncoder
-from ..voxsigil_rag import VoxSigilRAG
+# VoxSigilRAG resides in the top-level VoxSigilRag package
+from VoxSigilRag.voxsigil_rag import VoxSigilRAG
 
 # Configure logging early
 logging.basicConfig(

--- a/Vanta/core/UnifiedVantaCore.py
+++ b/Vanta/core/UnifiedVantaCore.py
@@ -18,10 +18,13 @@ from collections import defaultdict
 from typing import Any, Callable, Dict, List, Optional
 
 from BLT import BLTEncoder
-from BLT.hybrid_middleware import HybridMiddleware
+# The HybridMiddleware implementation lives in BLT.hybrid_blt
+from BLT.hybrid_blt import HybridMiddleware
 from Vanta.interfaces.blt_encoder_interface import BaseBLTEncoder
 from Vanta.interfaces.hybrid_middleware_interface import BaseHybridMiddleware
-from Vanta.interfaces.real_supervisor_connector import RealSupervisorConnector
+# RealSupervisorConnector implementation lives in integration.real_supervisor_connector
+# RealSupervisorConnector is located in the top-level integration package
+from integration.real_supervisor_connector import RealSupervisorConnector
 from Vanta.interfaces.supervisor_connector_interface import BaseSupervisorConnector
 
 from ..integration.vanta_supervisor import VantaSupervisor
@@ -62,8 +65,6 @@ from agents import (
     SDKContext,
     SleepTimeComputeAgent,
     HoloMesh,
-    HOLOMeshConfig,
-    HOLOAgentConfig,
     NullAgent,
 )
 from agents.base import AGENT_SUBSYSTEM_MAP
@@ -367,8 +368,7 @@ class UnifiedVantaCore:
 
         # Initialize HOLO mesh runtime loader
         try:
-            holo_cfg = HOLOMeshConfig(agents={})
-            self.holo_mesh = HoloMesh(holo_cfg, agent_registry=self.registry)
+            self.holo_mesh = HoloMesh(agent_registry=self.registry)
         except Exception as e:
             logger.error(f"Failed to initialize HOLO mesh: {e}")
             self.holo_mesh = None
@@ -1106,9 +1106,7 @@ class UnifiedVantaCore:
         for agent_name, agent in all_agents:
             agent_capabilities = []  # Try to get capabilities from agent metadata in registry
             if (
-                hasattr(self.agent_registry, "agents")
-                and self.agent_registry is not None
-                and self.agent_registry is not None
+                self.agent_registry is not None
                 and hasattr(self.agent_registry, "agents")
                 and agent_name in self.agent_registry.agents
             ):

--- a/Vanta/interfaces/__init__.py
+++ b/Vanta/interfaces/__init__.py
@@ -26,8 +26,11 @@ from .specialized_interfaces import (
     BLTInterface,
     ARCInterface,
     ARTInterface,
-    MiddlewareInterface
+    MiddlewareInterface,
 )
+from .blt_encoder_interface import BaseBLTEncoder
+from .hybrid_middleware_interface import BaseHybridMiddleware
+from .supervisor_connector_interface import BaseSupervisorConnector
 
 from .protocol_interfaces import (
     VantaProtocol,
@@ -50,6 +53,9 @@ __all__ = [
     'ARCInterface',
     'ARTInterface',
     'MiddlewareInterface',
+    'BaseBLTEncoder',
+    'BaseHybridMiddleware',
+    'BaseSupervisorConnector',
     
     # Protocol Interfaces
     'VantaProtocol',

--- a/Vanta/interfaces/blt_encoder_interface.py
+++ b/Vanta/interfaces/blt_encoder_interface.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+"""Base interface for BLT encoder implementations."""
+
+from abc import ABC, abstractmethod
+from .specialized_interfaces import BLTInterface
+
+
+class BaseBLTEncoder(BLTInterface, ABC):
+    """Interface defining core methods for BLT encoder components."""
+
+    @abstractmethod
+    async def encode(self, text: str) -> list[float]:
+        """Encode text into an embedding vector."""
+
+    @abstractmethod
+    def get_status(self) -> dict:
+        """Return health or configuration status."""

--- a/Vanta/interfaces/hybrid_middleware_interface.py
+++ b/Vanta/interfaces/hybrid_middleware_interface.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+"""Interface for hybrid middleware implementations used in Vanta."""
+
+from abc import ABC, abstractmethod
+from .specialized_interfaces import MiddlewareInterface
+
+
+class BaseHybridMiddleware(MiddlewareInterface, ABC):
+    """Base hybrid middleware contract."""
+
+    @abstractmethod
+    def get_middleware_capabilities(self) -> list[str]:
+        """Return a list of supported capability identifiers."""
+
+    @abstractmethod
+    def configure_middleware(self, config: dict) -> bool:
+        """Configure middleware with the provided settings."""

--- a/Vanta/interfaces/supervisor_connector_interface.py
+++ b/Vanta/interfaces/supervisor_connector_interface.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+"""Supervisor connector interface for Vanta components."""
+
+from abc import ABC, abstractmethod
+
+
+class BaseSupervisorConnector(ABC):
+    """Abstract base class for supervisor connectors."""
+
+    @abstractmethod
+    def get_sigil_content_as_dict(self, sigil_ref: str) -> dict | None:
+        """Retrieve sigil content as a dictionary."""
+
+    @abstractmethod
+    def create_sigil(self, sigil_ref: str, content: dict, sigil_type: str) -> None:
+        """Create or update a sigil entry."""

--- a/integration/real_supervisor_connector.py
+++ b/integration/real_supervisor_connector.py
@@ -13,7 +13,8 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from .supervisor_connector_interface import BaseSupervisorConnector
+# Use the shared interface from Vanta.interfaces
+from Vanta.interfaces.supervisor_connector_interface import BaseSupervisorConnector
 
 logger = logging.getLogger("VoxSigil.RealSupervisorConnector")
 


### PR DESCRIPTION
## Summary
- allow BLT module to run without jsonschema or numpy
- fix HybridMiddleware import for VoxSigilRag
- correct imports in UnifiedVantaCore
- add missing interface stubs for BLT encoder, hybrid middleware, and supervisor connector
- link RealSupervisorConnector to the shared interface
- simplify HOLO mesh initialization

## Testing
- `python test/agent_validation.py`
- `pytest -q` *(fails: SystemExit)*

------
https://chatgpt.com/codex/tasks/task_e_684a447117f8832490070ed37f4d070d