### PR TITLE
Fix ART imports for vanta_agent

### DIFF
--- a/ART/art_controller.py
+++ b/ART/art_controller.py
@@ -24,7 +24,7 @@ from .art_logger import get_art_logger  # Use the new logger
 
 # HOLO-1.5 Cognitive Mesh Integration
 try:
-    from ..core.vanta_registration import vanta_agent, CognitiveMeshRole, BaseAgent
+    from ..agents.base import vanta_agent, CognitiveMeshRole, BaseAgent
     from ..core.base_agent import VantaAgentCapability
     HOLO_AVAILABLE = True
 except ImportError:

--- a/ART/art_manager.py
+++ b/ART/art_manager.py
@@ -23,7 +23,7 @@ from .art_logger import get_art_logger
 
 # HOLO-1.5 Cognitive Mesh Integration
 try:
-    from ..core.vanta_registration import vanta_agent, CognitiveMeshRole, BaseAgent
+    from ..agents.base import vanta_agent, CognitiveMeshRole, BaseAgent
     from ..core.base_agent import VantaAgentCapability
     HOLO_AVAILABLE = True
 except ImportError:


### PR DESCRIPTION
## Summary
- ensure ART modules import registration utilities from agents package
- regenerate agent validation output

## Testing
- `python test/agent_validation.py`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684a7f0ad23483249cadceb329dd0c59