### PR TITLE
Fix ART imports for vanta_agent

### DIFF
--- a/ART/art_controller.py
+++ b/ART/art_controller.py
@@ -24,8 +24,7 @@ from .art_logger import get_art_logger  # Use the new logger
 
 # HOLO-1.5 Cognitive Mesh Integration
 try:
-    from ..core.vanta_registration import vanta_agent, CognitiveMeshRole, BaseAgent
-    from ..core.base_agent import VantaAgentCapability
+    from ..agents.base import vanta_agent, CognitiveMeshRole, BaseAgent
     HOLO_AVAILABLE = True
 except ImportError:
     HOLO_AVAILABLE = False
@@ -34,17 +33,18 @@ except ImportError:
         def decorator(cls):
             return cls
         return decorator
-    
+
     class CognitiveMeshRole:
         PROCESSOR = "processor"
-    
+
     class BaseAgent:
         pass
-    
-    class VantaAgentCapability:
-        PATTERN_RECOGNITION = "pattern_recognition"
-        ADAPTIVE_LEARNING = "adaptive_learning"
-        CATEGORY_FORMATION = "category_formation"
+
+# Capability constants
+class VantaAgentCapability:
+    PATTERN_RECOGNITION = "pattern_recognition"
+    ADAPTIVE_LEARNING = "adaptive_learning"
+    CATEGORY_FORMATION = "category_formation"
 
 # Use TYPE_CHECKING to avoid circular imports
 if TYPE_CHECKING:

--- a/ART/art_manager.py
+++ b/ART/art_manager.py
@@ -23,8 +23,7 @@ from .art_logger import get_art_logger
 
 # HOLO-1.5 Cognitive Mesh Integration
 try:
-    from ..core.vanta_registration import vanta_agent, CognitiveMeshRole, BaseAgent
-    from ..core.base_agent import VantaAgentCapability
+    from ..agents.base import vanta_agent, CognitiveMeshRole, BaseAgent
     HOLO_AVAILABLE = True
 except ImportError:
     HOLO_AVAILABLE = False
@@ -33,17 +32,18 @@ except ImportError:
         def decorator(cls):
             return cls
         return decorator
-    
+
     class CognitiveMeshRole:
         MANAGER = "manager"
-    
+
     class BaseAgent:
         pass
-    
-    class VantaAgentCapability:
-        ORCHESTRATION = "orchestration"
-        COMPONENT_MANAGEMENT = "component_management"
-        RESOURCE_COORDINATION = "resource_coordination"
+
+# Capability constants
+class VantaAgentCapability:
+    ORCHESTRATION = "orchestration"
+    COMPONENT_MANAGEMENT = "component_management"
+    RESOURCE_COORDINATION = "resource_coordination"
 
 
 @vanta_agent(


### PR DESCRIPTION
## Summary
- ensure ART modules import registration utilities from agents package
- define capability constants locally for HOLO fallback

## Testing
- `python test/agent_validation.py`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684a7f0ad23483249cadceb329dd0c59