### PR TITLE
Fix Vanta imports and agent validation

### DIFF
--- a/test/agent_validation.py
+++ b/test/agent_validation.py
@@ -4,7 +4,8 @@ import json
 import re
 from pathlib import Path
 
-MANIFEST_FILE = Path("AGENTS.md")
+# Path to the agent manifest. The file lives in docs/reports
+MANIFEST_FILE = Path("docs/reports/AGENTS.md")
 AGENT_DIR = Path("agents")
 
 pattern = re.compile(r"^\|\s*(?P<sigil>[^|]+)\|\s*(?P<name>[^|]+)\|\s*(?P<arch>[^|]+)\|\s*(?P<class>[^|]+)\|\s*(?P<inv>[^|]+)\|\s*(?P<subs>[^|]+)\|\s*(?P<notes>[^|]+)\|")

--- a/working_gui/complete_live_gui.py
+++ b/working_gui/complete_live_gui.py
@@ -8,6 +8,12 @@ import logging
 import sys
 import time  # Added for performance profiling
 import traceback
+from pathlib import Path
+
+# Ensure the repository root is on sys.path so 'Vanta' can be imported
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 # --- VoxSigil Core Engine Imports (Patched for Real Components) ---
 from ARC.arc_integration import HybridARCSolver as ARCIntegration

--- a/working_gui/complete_live_gui_new.py
+++ b/working_gui/complete_live_gui_new.py
@@ -8,6 +8,12 @@ import logging
 import sys
 import time  # Added for performance profiling
 import traceback
+from pathlib import Path
+
+# Ensure the repository root is on sys.path so 'Vanta' can be imported
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 # Set up logging
 logging.basicConfig(


### PR DESCRIPTION
## Summary
- ensure working GUI scripts include repository root in `sys.path`
- correct path for AGENT manifest in test helper
- regenerate agent reports

## Testing
- `python test/agent_validation.py`
- `pytest -q` *(fails: ModuleNotFoundError and import mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_6851998fc66c832485806009b0a3993b